### PR TITLE
Clean up css

### DIFF
--- a/static/window/index.html
+++ b/static/window/index.html
@@ -5,7 +5,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html">
     <!-- Styles -->
-    <link href="./styles/styles.css" type="text/css" rel="stylesheet">
+    <link href="./styles/core.css" type="text/css" rel="stylesheet">
+    <link href="./styles/fancy.css" type="text/css" rel="stylesheet">
   </head>
   <body>
     <div class="root" id="root"></div>

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1331,7 +1331,7 @@ body {
 }
 /* Playlist-List-Item Content */
 .playlist-list-item__content {
-  max-height: 0; /* Overriden with JavaScript when expanded */
+  max-height: 0; /* Overridden with JavaScript when expanded. */
   overflow: hidden;
   transition: max-height 0.2s ease-in-out;
 }

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -21,45 +21,11 @@ html, body {
 :root {
   /* Root font size (Scales most stuff) */
   font-size: 1em;
-  /* Theme Variables */
-  --theme__font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-  --theme__text-color: #f1f1f1;
-  --theme__text-disabled-color: #9b9b9b;
-  --theme__background-color: #1b1b1c;
-  --theme__search-bar__background-color: #1b1b1d;
-  --theme__search-bar__outline-color: #47474d;
-  --theme__title-bar__background-color: #141417;
-  --theme__scrollbar__color: #585858;
-  --theme__scrollbar__color-hover: #505050;
-  --theme__scrollbar__color-active: #404040;
-  --theme__slider__color: #4d4f55;
-  --theme__slider__color-hover: #43454b;
-  --theme__slider__color-active: #2e2f33;
-  --theme__browse-sidebar__background-color: #181819;
-  --theme__browse-sidebar__divider__background-color: #131313;
-  --theme__header__background-color: #2d2d30;
-  --theme__footer__background-color: #2a2a2b;
-  --theme__playlist-list-item-even__background-color: #1e1e1f;
-  --theme__playlist-list-fake-item__background-color: #19191b;
-  --theme__game-item__color: #aaaaaa;
-  --theme__game-item__color-hover: #e6e6e6;
-  --theme__game-item__color-selected: #cecece;
-  --theme__game-item__color-selected-hover: #e6e6e6;
-  --theme__game-item__background-color-hover: #3c3c41;
-  --theme__game-item__background-color-selected: #791c76;
-  --theme__game-item__background-color-selected-hover: #a72aa2;
-  --theme__game-list-item__background-color-even: #1e1e1f;
-  --theme__game-item-thumb__image-rendering: normal;
-  /* Pimp */
-  color: var(--theme__text-color);
   font-weight: 100;
 }
 
 body {
   overflow: hidden;
-  /* Pimp */
-  background-color: var(--theme__background-color);
-  font-family: var(--theme__font-family);
 }
 
 /* Measure elements by the outline of their border instead of by their content */
@@ -70,19 +36,12 @@ body {
   box-sizing: inherit;
 }
 
-:link {
-  color: #FFFFFF;
-}
-
 
 /* ------ Icons ------ */
 .icon {
   display: inline-block;
   width: 1rem;
   height: 1rem;
-}
-.icon__use {
-  fill: #ffffff;
 }
 
 
@@ -105,39 +64,18 @@ body {
 .simple-button {
   padding: 0 0.2em;
   font-size: 1em;
-  background-color: #2d2d30;
-  border: 1px solid var(--theme__search-bar__outline-color);
-  color: var(--theme__text-color);
+  border: 1px solid;
   user-select: none;
-}
-.simple-button:hover {
-  background-color: #434346;
-  border-color: #6f6f75;
-}
-.simple-button:disabled {
-  color: var(--theme__text-disabled-color);
-}
-.simple-button--red {
-  background-color: #5a1010;
-  border-color: #731919;
-}
-.simple-button--red:hover {
-  background-color: #731616;
-  border-color: #a22020;
 }
 /* Simple Selector */
 .simple-selector {
   margin-right: 0.5em;
   font-size: 1em;
   font-weight: 100;
-  border: 1px solid var(--theme__search-bar__outline-color);
+  border: 1px solid;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  /* Pimp */
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
-  color: var(--theme__text-color);
 }
 /* Hidden Slider */
 .hidden-slider {
@@ -189,27 +127,8 @@ body {
   width: var(--scrollbar-size);
   height: var(--scrollbar-size);
 }
-.simple-scroll::-webkit-scrollbar-track {
-  box-shadow: inset 0 0 calc(0.25 * var(--scrollbar-size)) rgba(0, 0, 0, 0.25);
-  background-color: rgba(0, 0, 0, 0.085);
-  border-radius: calc(0.5 * var(--scrollbar-size));
-}
-.simple-scroll::-webkit-scrollbar-thumb {
-  box-shadow: inset 0 0 calc(0.5 * var(--scrollbar-size));
-  border-radius: calc(0.5 * var(--scrollbar-size));
-  background-color: var(--theme__scrollbar__color);
-  color: rgba(0, 0, 0, 0.15);
-}
-.simple-scroll::-webkit-scrollbar-thumb:hover {
-  background-color: var(--theme__scrollbar__color-hover);
-}
-.simple-scroll::-webkit-scrollbar-thumb:active {
-  background-color: var(--theme__scrollbar__color-active);
-}
 /* Simple Input (Input text field) */
 .simple-input {
-  color: var(--theme__text-color);
-  background-color: #313131;
   border: none;
 }
 /* Simple Disabled Text */
@@ -217,7 +136,6 @@ body {
   cursor: default;
   user-select: none;
   font-style: italic;
-  color: #868686;
 }
 /* Input Field */
 .input-field {
@@ -244,10 +162,6 @@ body {
 .checkbox-dropdown {
   --width: 11rem;
   width: var(--width);
-  /* Pimp */
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
-  color: var(--theme__text-color);
 }
 .checkbox-dropdown__select-box {
   position: relative;
@@ -256,18 +170,14 @@ body {
   /* Pimp */
   appearance: menulist-button;
   -webkit-appearance: menulist-button;
-  background-color: var(--theme__background-color);
-  color: var(--theme__text-color);
-  border: 1px solid var(--theme__search-bar__outline-color);
+  border: 1px solid;
 }
 .checkbox-dropdown__content {
   width: var(--width);
   display: block;
   position: absolute;
   /* Pimp */
-  background-color: var(--theme__background-color);
-  color: var(--theme__text-color);
-  border: 1px solid var(--theme__search-bar__outline-color);
+  border: 1px solid;
 }
 .checkbox-dropdown__content--hidden {
   display: none;
@@ -279,17 +189,10 @@ body {
   display: inline-block;
   overflow: hidden;
 }
-.checkbox-dropdown__content label:hover {
-  background-color: #1e90ff;
-}
 /* Input Dropdown */
 .input-dropdown {
   position: relative;
   height: 100%;
-  /* Pimp */
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
-  color: var(--theme__text-color);
 }
 .input-dropdown__input-field {
   position: relative;
@@ -306,8 +209,6 @@ body {
   /* Pimp */
   appearance: menulist-button;
   -webkit-appearance: menulist-button;
-  background-color: #313131;
-  color: var(--theme__text-color);
   border: none;
 }
 .input-dropdown__input-field__input {
@@ -330,9 +231,7 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
   /* Pimp */
-  background-color: #313131;
-  color: var(--theme__text-color);
-  border: 1px solid var(--theme__search-bar__outline-color);
+  border: 1px solid;
 }
 .input-dropdown__content--hidden {
   display: none;
@@ -344,35 +243,10 @@ body {
   display: inline-block;
   overflow: hidden;
 }
-.input-dropdown__content label:hover,
-.input-dropdown__content label:focus {
-  background-color: #1e90ff;
-}
 /* Log */
 .log {
   height: 100%;
   overflow: scroll;
-  /* Pimp */
-  color: white;
-}
-.log__time-stamp {
-  color: #857df3;
-}
-.log__source {
-  /* Default color of sources, used on the unknown/unspecified sources */
-  color: #d4d4d4;
-}
-.log__source--background-services {
-  color: #8d8d8d;
-}
-.log__source--game-launcher {
-  color: #ffd900;
-}
-.log__source--router {
-  color: #00ff00;
-}
-.log__source--redirector {
-  color: #00ffff;
 }
 /* Simple Columns */
 .simple-columns {
@@ -437,7 +311,6 @@ body {
   height: 100%;
   /* Pimp */
   padding: 2rem;
-  background-color: rgba(0, 0, 0, 0.8);
 }
 .image-preview * {
   user-select: none;
@@ -460,14 +333,10 @@ body {
   flex-direction: column;
   width: 100%;
   height: 100%;
-  /* Pimp */
-  background-color: var(--theme__title-bar__background-color);
 }
 .main {
   flex: 1;
   overflow: hidden;
-  /* Pimp */
-  background-color: var(--theme__background-color);
 }
 
 
@@ -480,8 +349,6 @@ body {
   margin: 4px 0 0 4px;
   -webkit-app-region: drag; /* Dragging this moves the window */
   -webkit-user-select: none; /* Disable text selection */
-  /* Pimp */
-  background-color: var(--theme__title-bar__background-color);
 }
 /* Title */
 .title-bar__title {
@@ -523,27 +390,6 @@ body {
 .title-bar__button-bar__cross:hover {
   opacity: 1;
 }
-/* Minimize Button */
-.title-bar__button-bar__min {
-  background-image: url('../images/min.png');
-}
-.title-bar__button-bar__min:hover {
-  background-color: #242428;
-}
-/* Maximize Button */
-.title-bar__button-bar__max {
-  background-image: url('../images/max.png');
-}
-.title-bar__button-bar__max:hover {
-  background-color: #242428;
-}
-/* Cross Button */
-.title-bar__button-bar__cross {
-  background-image: url('../images/cross.png');
-}
-.title-bar__button-bar__cross:hover {
-  background-color: #eb4b4b;
-}
 
 
 /* ------ Header ------ */
@@ -554,8 +400,6 @@ body {
   font-size: 0.75em;
   padding: var(--header-padding);
   padding-bottom: 0.4em;
-  /* Pimp */
-  background-color: var(--theme__header__background-color);
 }
 .header__wrap {
   min-height: 2rem;
@@ -586,15 +430,6 @@ body {
   display: inline-block;
   padding: 0.3em 0.7em;
   border: 1px solid rgba(0,0,0,0);
-  /* Pimp */
-  cursor: pointer;
-  text-decoration: none;
-  color: var(--theme__text-color);
-}
-.header__menu__item__link:hover {
-  /* Pimp */
-  background-color: #3c2d4b;
-  border-color: #d33682;
 }
 /* Header Search */
 .header__search__wrap {
@@ -605,9 +440,6 @@ body {
   display: flex;
   padding: 0.25em;
   overflow: hidden;
-  /* Pimp */
-  border: 1px solid var(--theme__search-bar__outline-color);
-  background-color: var(--theme__search-bar__background-color);
 }
 .header__search__left {
   flex: 1 1 auto;
@@ -628,46 +460,13 @@ body {
   width: 0.9em;
   height: 0.9em;
 }
-.header__search__icon .icon__use {
-  fill: var(--theme__text-color);
-}
-.header__search__icon:hover .icon__use--circle-x {
-  fill: #b1b1b1;
-}
-.header__search__input, .header__search__input:active {
+.header__search__input,
+.header__search__input:active {
   font-size: 1em;
   width: 100%;
-  color: var(--theme__text-color);
   background: none;
   border: none;
   outline: none;
-}
-.header__search__tag {
-  /* Pimp */
-  border: 1px solid #888;
-  background-color: #aaa;
-}
-.header__search__tag__text,
-.header__search__tag__text:active {
-  /* Pimp */
-}
-.header__search__tag__remove {
-  /* Pimp */
-  /*
-  border: 0.1em solid #800;
-  border-radius: 999em;
-  background-color: #a00;
-  font-size: 0.75rem;
-  */
-}
-.header__search__tag__remove:hover {
-  /* Pimp */
-  cursor: pointer;
-}
-.header__search__tag__remove__inner {
-  /* Pimp */
-  color: #c00;
-  font-family: monospace, monospace;
 }
 /* Header Toggle-Sidebar */
 .header__toggle-sidebar {
@@ -676,15 +475,6 @@ body {
 }
 .header__toggle-sidebar:hover {
   cursor: pointer;
-}
-.header__toggle-sidebar .icon__use {
-  fill: #ccc;
-}
-.header__toggle-sidebar:hover .icon__use {
-  fill: #fff;
-}
-.header__toggle-sidebar:active .icon__use {
-  fill: #aaa;
 }
 
 
@@ -695,7 +485,6 @@ body {
   padding: 0.05rem 0.2rem;
   /* Pimp */
   user-select: none;
-  background-color: var(--theme__footer__background-color);
 }
 .footer__wrap {
   padding: 0.025rem;
@@ -745,9 +534,6 @@ body {
   position: relative;
   height: var(--slider-size);
   cursor: pointer;
-  background-color: #353838;
-  box-shadow: inset 0 0 calc(0.5 * var(--slider-size)) rgba(0, 0, 0, 0.05);
-  border-radius: calc(0.5 * var(--slider-size));
 }
 .footer__scale-slider__icon {
   position: absolute;
@@ -755,9 +541,6 @@ body {
   top: 50%;
   transform: translateY(-50%);
   font-size: 1.2em;
-  font-family: monospace;
-  font-weight: bold;
-  color: #0f1010;
 }
 .footer__scale-slider__icon--left {
   left: 0.25rem;
@@ -766,7 +549,6 @@ body {
   left: 50%;
   width: 1px;
   height: 60%;
-  background-color: #0f1010;
 }
 .footer__scale-slider__icon--right {
   right: 0.25rem;
@@ -775,22 +557,6 @@ body {
   width: 100%;
   height: 100%;
   position: absolute;
-  background: none;
-}
-.footer__scale-slider__input::-webkit-slider-runnable-track {
-  background: none;
-}
-.footer__scale-slider__input::-webkit-slider-thumb {
-  box-shadow: inset 0 0 calc(0.5 * var(--slider-size));
-  border-radius: 50%;
-  background-color: var(--theme__slider__color);
-  color: rgba(0, 0, 0, 0.05);
-}
-.footer__scale-slider__input::-webkit-slider-thumb:hover {
-  background-color: var(--theme__slider__color-hover);
-}
-.footer__scale-slider__input::-webkit-slider-thumb:active {
-  background-color: var(--theme__slider__color-active);
 }
 .footer__scale-percent {
   display: block;
@@ -823,20 +589,6 @@ body {
   --zoom: 1800%;
   width: 100%;
   height: 100%;
-  /* Mask the background color with the FP logo */
-    -webkit-mask: url('../images/logo-solid.svg');
-  -webkit-mask-size: var(--size);
-  -webkit-mask-repeat: no-repeat;
-  /* Cool colors yall */
-  background:
-    linear-gradient(#00000000, var(--theme__background-color)),
-    linear-gradient(90deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3, #ff2400);
-  background-size: var(--zoom) 100%;
-  -webkit-animation: home-page__logo__slide 1200s linear infinite;
-}
-@-webkit-keyframes home-page__logo__slide {
-     0% { background-position-x:          0%; }
-   100% { background-position-x: var(--zoom); }
 }
 /* HomePage Box */
 .home-page__box {
@@ -844,12 +596,11 @@ body {
   margin: 0 auto;
   margin-bottom: 1rem;
   width: 30em;
-  border: 1px #3f3f3f solid;
-  background-color: #252525;
+  border: 1px solid;
 }
 .home-page__box__head {
   padding: 0.15rem 0.3rem;
-  border-bottom: 1px #3f3f3f solid;
+  border-bottom: 1px solid;
   font-weight: bold;
 }
 .home-page__box__body {
@@ -872,14 +623,6 @@ body {
   display: block;
   text-align: center;
   white-space: pre-line;
-}
-.home-page__box--upgrades .home-page__grayed-out {
-  color: var(--theme__text-disabled-color);
-}
-/* HomePage Box - Extras */
-.home-page__box--extras span a {
-  background: #404040;
-  text-decoration: none;
 }
 /* Random Games */
 .home-page__random-games {
@@ -972,7 +715,6 @@ body {
 .about-page__section__title {
   font-size: 1.4rem;
   padding-left: 0.4rem;
-  background-color: #141417;
 }
 .about-page__section__content {
   padding-left: 0.4rem;
@@ -1014,13 +756,7 @@ body {
   position: absolute;
   pointer-events: none;
   z-index: 1;
-  border: 1px solid black;
-  background-color: #000000DD;
-}
-.about-page__credits__tooltip__title {}
-.about-page__credits__tooltip__note {
-  color: var(--theme__text-disabled-color);
-  font-style: italic;
+  border: 1px solid;
 }
 .about-page__credits__tooltip__roles {
   --indent: 0.5em;
@@ -1029,7 +765,6 @@ body {
 }
 .about-page__credits__tooltip__roles p {
   display: inline;
-  background-color: #000000;
 }
 
 
@@ -1048,7 +783,6 @@ body {
   padding: 0.2rem 0.3rem;
   font-size: 0.85rem;
   user-select: none;
-  background-color: #222222;
 }
 .log-page__bar__wrap {
   padding: 0.025rem;
@@ -1079,7 +813,6 @@ body {
   display: flex;
   width: 100%;
   height: 100%;
-  background-color: var(--theme__background-color);
 }
 /* Center */
 .game-browser__center {
@@ -1097,7 +830,6 @@ body {
   flex: 0 0 auto;
   min-width: var(--divider-width);
   max-width: 100%;
-  background-color: var(--theme__browse-sidebar__background-color);
 }
 .game-browser__sidebar--hidden {
   display: none;
@@ -1116,24 +848,17 @@ body {
 .game-browser__sidebar__divider {
   width: var(--divider-width);
   flex: 0 0 auto;
-  background-color: var(--theme__browse-sidebar__divider__background-color);
   user-select: none;
   cursor: ew-resize;
 }
 /* Right Sidebar */
-.game-browser__right {}
 .game-browser__right p {
   display: inline;
 }
-
 /* Browse-Left-Sidebar */
-.browse-left-sidebar {
-  
-}
 .browse-left-sidebar > .playlist-list {
   width: 100%;
 }
-
 /* Browse-Right-Sidebar */
 .browse-right-sidebar {
   display: flex;
@@ -1158,9 +883,6 @@ body {
 /* Browse-Right-Sidebar Additional-Application */
 .browse-right-sidebar__additional-application {
   padding: 0.5rem;
-}
-.browse-right-sidebar__additional-application:nth-child(2n) {
-  background-color: #141417;
 }
 .browse-right-sidebar__additional-application__delete-button {
   float: right;
@@ -1250,38 +972,6 @@ body {
   height: 0.9rem;
   width: 0.9rem;
 }
-.browse-right-sidebar__title-row__buttons .icon__use {
-  fill: var(--theme__text-color);
-}
-.browse-right-sidebar__title-row__buttons :hover .icon__use {
-  fill: #b1b1b1;
-}
-/* BrowseSidebar Title-Row Delete-Game */
-.browse-right-sidebar__title-row__buttons__delete-game:hover .icon__use {
-  fill: #aa4b4b;
-}
-.browse-right-sidebar__title-row__buttons__delete-game--active:hover .icon__use {
-  fill: #8a1212;
-}
-/* BrowseSidebar Title-Row Remove-From-Playlist */
-.browse-right-sidebar__title-row__buttons__remove-from-playlist:hover .icon__use {
-  fill: #aa4b4b;
-}
-.browse-right-sidebar__title-row__buttons__remove-from-playlist--active:hover .icon__use {
-  fill: #8a1212;
-}
-/* BrowseSidebar Title-Row Edit */
-.browse-right-sidebar__title-row__buttons__edit-button:hover .icon__use {
-  fill: #5cb468;
-}
-/* BrowseSidebar Title-Row Discard */
-.browse-right-sidebar__title-row__buttons__discard-button:hover .icon__use {
-  fill: #aa4b4b;
-}
-/* BrowseSidebar Title-Row Save */
-.browse-right-sidebar__title-row__buttons__save-button:hover .icon__use {
-  fill: #5cb468;
-}
 /* Browse-Right-Sidebar Row - Sub Elements */
 .browse-right-sidebar__row__check-box-wrapper {
   display: contents;
@@ -1312,8 +1002,7 @@ body {
   width: 100%;
   height: 15rem;
   overflow: hidden;
-  background-color: #1b1b1b;
-  border: 2px #818181 dashed;
+  border: 2px dashed;
   user-select: none;
   position: relative;
 }
@@ -1338,7 +1027,6 @@ body {
 .browse-right-sidebar__row__screenshot__placeholder p {
   font-size: 0.9rem;
   font-style: italic;
-  color: var(--theme__text-disabled-color);
 }
 .browse-right-sidebar__row__screenshot img {
   width: 100%;
@@ -1346,7 +1034,6 @@ body {
 }
 /* GameImageSplit */
 .game-image-split {
-  --inner-border-color: #313131;
   flex: 1 1 auto;
   width: 50%;
   text-align: center;
@@ -1354,18 +1041,12 @@ body {
   background-repeat: no-repeat;
   background-position: center;
 }
-.game-image-split--hover {
-  background-color: #575757;
-}
-.game-image-split--disabled {
-  background-color: #141414;
-}
 .game-image-split:first-child {
-  border-right: 1px var(--inner-border-color) dashed;
+  border-right: 1px dashed;
   margin-bottom: -1px;
 }
 .game-image-split:last-child {
-  border-left: 1px var(--inner-border-color) dashed;
+  border-left: 1px dashed;
   margin: -1px;
 }
 .game-image-split__buttons {
@@ -1377,12 +1058,6 @@ body {
 }
 .game-image-split__buttons > p {
   float: left;
-}
-.game-image-split__buttons__remove-image:hover .icon__use {
-  fill: #aa4b4b;
-}
-.game-image-split__buttons__remove-image--active:hover .icon__use {
-  fill: #8a1212;
 }
 .game-image-split__not-found {
   display: inline-block;
@@ -1411,30 +1086,9 @@ body {
 /* GameList Item */
 .game-list-item {
   display: flex;
-  /* Pimp */
-  list-style: none;
-  background-color: var(--theme__background-color);
-  color: var(--theme__game-item__color);
-}
-.game-list-item--even {
-  /* Pimp */
-  background-color: var(--theme__game-list-item__background-color-even);
 }
 .game-list-item:hover {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-hover);
-  color: var(--theme__game-item__color-hover);
   cursor: pointer;
-}
-.game-list-item--selected {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-selected);
-  color: var(--theme__game-item__color-selected);
-}
-.game-list-item--selected:hover {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-selected-hover);
-  color: var(--theme__game-item__color-selected-hover);
 }
 .game-list-item--dragged {
   opacity: 0.4;
@@ -1447,7 +1101,6 @@ body {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  image-rendering: var(--theme__game-item-thumb__image-rendering);
 }
 /* GameList Item Right */
 .game-list-item__right {
@@ -1491,39 +1144,24 @@ body {
   font-size: 1.5rem;
 }
 
-/* GameList */
+/* GameGrid */
 .game-grid {
   /* --width | Width of grid items (in pixels) */
   /* --height | Height of grid items (in pixels) */
 }
-/* GameList Item */
+/* GameGrid Item */
 .game-grid-item {
   width: calc(1px * var(--width));
   height: calc(1px * var(--height));
-  /* Pimp */
   list-style: none;
-  color: var(--theme__game-item__color);
 }
 .game-grid-item:hover {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-hover);
-  color: var(--theme__game-item__color-hover);
   cursor: pointer;
-}
-.game-grid-item--selected {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-selected);
-  color: var(--theme__game-item__color-selected);
-}
-.game-grid-item--selected:hover {
-  /* Pimp */
-  background-color: var(--theme__game-item__background-color-selected-hover);
-  color: var(--theme__game-item__color-selected-hover);
 }
 .game-grid-item--dragged {
   opacity: 0.4;
 }
-/* GameList Item Thumb */
+/* GameGrid Item Thumb */
 .game-grid-item__thumb {
   padding: calc(var(--width) * 0.0025rem);
   width: calc(var(--width) * 1px);
@@ -1536,12 +1174,7 @@ body {
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;
-  /* Pimp */
-  border-radius: 0.2em;
-  background-color: #242428;
-  border: 1px solid #141417;
-  box-shadow: 0px 2px 4px 0px #09090a;
-  image-rendering: var(--theme__game-item-thumb__image-rendering);
+  border: 1px solid;
 }
 .game-grid-item__thumb__icons {
   width: 100%;
@@ -1557,7 +1190,7 @@ body {
   background-repeat: no-repeat;
   background-position: center;
 }
-/* GameList Item Title */
+/* GameGrid Item Title */
 .game-grid-item__title {
   padding: calc(var(--width) * 0.001rem);
   height: calc((var(--height) - var(--width)) * 0.001rem);
@@ -1576,7 +1209,7 @@ body {
   font-weight: bold;
   user-select: none;
 }
-/* GameList NoGames */
+/* GameGrid NoGames */
 .game-grid__no-games {
   width: 100%;
   height: 100%;
@@ -1604,28 +1237,6 @@ body {
   --image-padding: 0.15rem; /* Padding of the playlist item head */
 }
 /* Playlist-List-Item */
-.playlist-list-item {
-  list-style: none;
-  background-color: var(--theme__background-color);
-  color: #aaa;
-}
-.playlist-list-item:nth-child(2n) {
-  background-color: var(--theme__playlist-list-item-even__background-color);
-}
-.playlist-list-item:hover,
-.playlist-list-item.playlist-list-item--drag-over {
-  background-color: #3c3c41;
-}
-.playlist-list-item--editing {
-  background-color: #151f14;
-}
-.playlist-list-item--editing:nth-child(2n) {
-  background-color: #192519;
-}
-.playlist-list-item--editing:hover,
-.playlist-list-item--editing.playlist-list-item--drag-over {
-  background-color: #20301f;
-}
 .playlist-list-item--editing p {
   user-select: none; /* Can not select text while editing is enabled */
 }
@@ -1638,7 +1249,7 @@ body {
   top: 0;
   height: 100%;
   width: 100%;
-  border: 2px #818181 dashed;
+  border: 2px dashed;
 }
 /* Playlist-List-Item Head */
 .playlist-list-item__head {
@@ -1648,15 +1259,9 @@ body {
   padding-left: 0.3rem;
   cursor: pointer;
   overflow: hidden;
-  --color: #aaa;
-  color: var(--color);
 }
 .playlist-list-item--editing .playlist-list-item__head {
   cursor: default;
-}
-.playlist-list-item__head:hover,
-.playlist-list-item--drag-over .playlist-list-item__head {
-  --color: #e6e6e6;
 }
 .playlist-list-item__head > * {
   flex: 0 0 auto;
@@ -1679,9 +1284,6 @@ body {
 .playlist-list-item__head__icon__no-image__icon {
   width: 100%;
   height: 100%;
-}
-.playlist-list-item__head__icon__no-image__icon .icon__use {
-  fill: var(--color);
 }
 .playlist-list-item__head__title {
   flex: 0 1 auto;
@@ -1723,12 +1325,8 @@ body {
   max-height: 0; /* Overriden with JavaScript when expanded */
   overflow: hidden;
   transition: max-height 0.2s ease-in-out;
-  /* Pimp */
-  background-color: #242425;
 }
 .playlist-list-item--editing .playlist-list-item__content {
-  background-color: #1c291b;
-  color: #cecece;
   transition: max-height 0.15s;
 }
 .playlist-list-item__content__inner {
@@ -1771,7 +1369,6 @@ body {
   width: 100%;
   min-height: 5rem;
   resize: vertical;
-  background-color: #3a5637;
 }
 .playlist-list-item__content__description-text {
   white-space: pre-wrap;
@@ -1789,13 +1386,6 @@ body {
   height: calc(var(--image-size) + var(--image-padding) * 2);
   padding: var(--image-padding);
   padding-left: 0.5rem;
-  /* Pimp */
-  background-color: var(--theme__playlist-list-fake-item__background-color);
-  --color: #aaaaaa;
-}
-.playlist-list-fake-item:hover {
-  background-color: #343438;
-  --color: #ffffff;
 }
 .playlist-list-fake-item,
 .playlist-list-fake-item * {
@@ -1815,16 +1405,13 @@ body {
   width: var(--icon-size);
   height: var(--icon-size);
 }
-.playlist-list-fake-item__inner .icon__use {
-  fill: var(--color);
-}
 .playlist-list-fake-item__inner__title {
   font-size: 1.1rem;
   padding-left: 0.5rem;
-  color: var(--color);
   overflow: hidden;
   word-break: break-all;
 }
+
 
 /** ------ Developer ------ */
 .developer-page {
@@ -1847,11 +1434,11 @@ body {
 .developer-page__log {
   flex: 1 1 auto;
   height: 35rem;
-  background-color: #313133;
-  border: 1px #353535 solid;
+  border: 1px solid;
   border-radius: 0.5rem;
   text-align: left;
 }
+
 
 /** ------ Config ------ */
 .config-page {
@@ -1898,16 +1485,11 @@ body {
 .setting__body {
   /* Pimp */
   border-radius: 0.2em;
-  background-color: #242428;
-  border: 1px solid #141417;
-  box-shadow: 0px 2px 4px 0px #09090a;
+  border: 1px solid;
 }
 /* Setting Row */
 .setting__row {
   padding: 0.75em;
-}
-.setting__row:not(:first-child) {
-  border-top: 1px solid #141417;
 }
 .setting__row__top {
   display: flex;
@@ -1935,13 +1517,7 @@ body {
 }
 .setting__row__content--filepath-path .flashpoint-path__input {
   flex: 1;
-  border: 1px solid var(--theme__search-bar__outline-color);
-}
-.setting__row__content--filepath-path .flashpoint-path__input--valid {
-  background-color: #009600;
-}
-.setting__row__content--filepath-path .flashpoint-path__input--invalid {
-  background-color: #840000;
+  border: 1px solid;
 }
 .setting__row__content--filepath-path .flashpoint-path__input input[type="text"] {
   width: 100%;
@@ -1949,7 +1525,6 @@ body {
   background: none;
   border: none;
   outline: none;
-  color: var(--theme__text-color);
 }
 /* Setting Row Content - Toggle */
 .setting__row__content--toggle > div {
@@ -1978,10 +1553,5 @@ body {
   width: 100%;
 }
 .setting__row__content--input-field > :first-child > * {
-  border: 1px solid var(--theme__search-bar__outline-color);
-}
-/* Setting Row Content - Theme Input Field */
-.setting__row__content--theme-input-field label:last-child {
-  /* Change the color of the "No Theme" suggestion in the drop-down list. */
-  color: #bfbfbf;
+  border: 1px solid;
 }

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1564,6 +1564,7 @@ body {
 .setting__row__content--input-field > :first-child {
   width: 100%;
 }
-.setting__row__content--input-field > :first-child > * {
+.setting__row__content--input-field .input-dropdown__input-field,
+.setting__row__content--input-field .input-dropdown__content {
   border: 1px solid;
 }

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -1,3 +1,12 @@
+/* ====== CORE ======
+ * 
+ * Contains all styles that are necessary for the application to be used.
+ * This includes styles that set things like position, size, "user-select" etc.
+ * 
+ * The application should be completely usable with this stylesheet only.
+ * 
+ */
+
 /* ------ General ------ */
 * {
   margin: 0;
@@ -1490,6 +1499,9 @@ body {
 /* Setting Row */
 .setting__row {
   padding: 0.75em;
+}
+.setting__row:not(:first-child) {
+  border-top: 1px solid;
 }
 .setting__row__top {
   display: flex;

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -3,7 +3,7 @@
  * Contains all styles that are necessary for the application to be used.
  * This includes styles that set things like position, size, "user-select" etc.
  * 
- * The application should be completely usable with this stylesheet only.
+ * The application should be completely usable with this style-sheet only.
  * 
  */
 

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -3,7 +3,7 @@
  * Contains all styles that enhance the visuals of the application.
  * This includes things like text/background/border colors, fonts etc.
  *
- * This stylesheet should be compleley optional.
+ * This style-sheet should be completely optional.
  * 
  */
 

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -1,11 +1,29 @@
+/* ====== FANCY ======
+ * 
+ * Contains all styles that enhance the visuals of the application.
+ * This includes things like text/background/border colors, fonts etc.
+ *
+ * This stylesheet should be compleley optional.
+ * 
+ */
+
 /* ------ General ------ */
 :root {
   /* ------- Layout Variables ------- */
-  --color__aaa: var(--layout__secondary-text-color);
-  --color__playlist-description-while-edititng: #ffffff;
-  --color__no-theme-suggestion: #bfbfbf;
-  --color__foot-slider-icon: #0f1010;
-  /* Text */
+  /* Font */
+  --layout__primary-font: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  /* Confirm */
+  /*--layout__confirm-dark-color:   #5cb468;
+  --layout__confirm-medium-color: #5cb468;*/
+  --layout__confirm-bright-color: #5cb468;
+  /* Warning */
+  --layout__warning-dark-color:   #5a1010;
+  --layout__warning-medium-color: #731919;
+  --layout__warning-bright-color: #a22020;
+  /* Valid / Invalid */
+  --layout__valid-color:   #009600;
+  --layout__invalid-color: #840000;
+  /* Text Color */
   --layout__primary-text-color: #f1f1f1;
   --layout__secondary-text-color: #aaaaaa;
   --layout__highlighted-text-color: #ffffff;
@@ -13,41 +31,44 @@
   /* Background */
   --layout__primary-background: #1b1b1c;
   --layout__secondary-background: #2d2d30;
-  /* Theme Variables */
-  --theme__font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-  --theme__text-disabled-color: #9b9b9b;
-  --theme__background-color: #1b1b1c;
-  --theme__search-bar__background-color: #1b1b1d;
-  --theme__search-bar__outline-color: #47474d;
-  --theme__title-bar__background-color: #141417;
-  --theme__scrollbar__color: #585858;
-  --theme__scrollbar__color-hover: #505050;
-  --theme__scrollbar__color-active: #404040;
-  --theme__slider__color: #4d4f55;
-  --theme__slider__color-hover: #43454b;
-  --theme__slider__color-active: #2e2f33;
-  --theme__browse-sidebar__background-color: #181819;
-  --theme__browse-sidebar__divider__background-color: #131313;
-  --theme__header__background-color: #2d2d30;
-  --theme__footer__background-color: #2a2a2b;
-  --theme__playlist-list-item-even__background-color: #1e1e1f;
-  --theme__playlist-list-fake-item__background-color: #19191b;
-  --theme__game-item__color: #aaaaaa;
-  --theme__game-item__color-hover: #e6e6e6;
-  --theme__game-item__color-selected: #cecece;
-  --theme__game-item__color-selected-hover: #e6e6e6;
-  --theme__game-item__background-color-hover: #3c3c41;
-  --theme__game-item__background-color-selected: #791c76;
-  --theme__game-item__background-color-selected-hover: #a72aa2;
-  --theme__game-list-item__background-color-even: #1e1e1f;
-  --theme__game-item-thumb__image-rendering: normal;
-  /* Pimp */
-  color: var(--layout__primary-text-color);
+  --layout__tertiary-backround: #141417;
+  --layout__four-background: #242428;
+  /* Outline Color */
+  --layout__primary-outline-color: #47474d;
+  /* Scrollbar */
+  --layout__scroll-thumb-color: #585858;
+  --layout__scroll-thumb-color-hover: #505050;
+  --layout__scroll-thumb-color-active: #404040;
+  /* Slider */
+  --layout__slider-background: #4d4f55;
+  --layout__slider-background-hover: #43454b;
+  --layout__slider-background-active: #2e2f33;
+  /* Game Item */
+  --layout__game-item-color: var(--layout__secondary-text-color);
+  --layout__game-item-color-hover: var(--layout__primary-text-color);
+  --layout__game-item-color-selected: #cecece;
+  --layout__game-item-color-selected-hover: var(--layout__game-item-color-hover);
+  --layout__game-list-item-background-even: #1e1e1f; /* Only used in "list" mode. */
+  --layout__game-item-background-hover: #3c3c41;
+  --layout__game-item-background-selected: #791c76;
+  --layout__game-item-background-selected-hover: #a72aa2;
+  --layout__game-item-thumb-image-rendering: normal; /* Used to set the "image-rendering" of the thumbnail. */
+  /* Browse Sidebar */
+  --layout__browse-sidebar-background: #181819;
+  --layout__browse-sidebar-divider-background: #131313;
+  /* Playlist List */
+  --layout__playlist-list-item-even-background: #1e1e1f;
+  --layout__playlist-list-fake-even-background: #19191b;
+  /* Misc */
+  --layout__title-bar-cross-color: #eb4b4b;
+  --layout__no-theme-suggestion-color: #bfbfbf;
+  --layout__footer-scale-slider-icon-color: #0f1010;
 }
 
 body {
-  background-color: var(--theme__background-color);
-  font-family: var(--theme__font-family);
+  color: var(--layout__primary-text-color);
+  background-color: var(--layout__primary-background);
+  font-family: var(--layout__primary-font);
 }
 
 :link {
@@ -64,8 +85,8 @@ body {
 /* ------ Generic & Re-usable ------ */
 /* Simple Button */
 .simple-button {
-  background-color: #2d2d30;
-  border-color: var(--theme__search-bar__outline-color);
+  background-color: var(--layout__secondary-background);
+  border-color: var(--layout__primary-outline-color);
   color: var(--layout__primary-text-color);
 }
 .simple-button:hover {
@@ -73,22 +94,22 @@ body {
   border-color: #6f6f75;
 }
 .simple-button:disabled {
-  color: var(--theme__text-disabled-color);
+  color: var(--layout__disabled-text-color);
 }
 .simple-button--red {
-  background-color: #5a1010;
-  border-color: #731919;
+  background-color: var(--layout__warning-dark-color);
+  border-color: var(--layout__warning-medium-color);
 }
 .simple-button--red:hover {
-  background-color: #731616;
-  border-color: #a22020;
+  background-color: var(--layout__warning-medium-color);
+  border-color: var(--layout__warning-bright-color);
 }
 /* Simple Selector */
 .simple-selector {
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
   /* Pimp */
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
+  font-family: var(--layout__primary-font);
+  background-color: var(--layout__primary-background);
   color: var(--layout__primary-text-color);
 }
 /* Simple Scroll(bar) */
@@ -97,16 +118,22 @@ body {
   background-color: rgba(0, 0, 0, 0.085);
   border-radius: calc(0.5 * var(--scrollbar-size));
 }
+.simple-scroll::-webkit-scrollbar-thumb {
+  box-shadow: inset 0 0 calc(0.5 * var(--scrollbar-size));
+  border-radius: calc(0.5 * var(--scrollbar-size));
+  background-color: var(--layout__scroll-thumb-color);
+  color: rgba(0, 0, 0, 0.15);
+}
 .simple-scroll::-webkit-scrollbar-thumb:hover {
-  background-color: var(--theme__scrollbar__color-hover);
+  background-color: var(--layout__scroll-thumb-color-hover);
 }
 .simple-scroll::-webkit-scrollbar-thumb:active {
-  background-color: var(--theme__scrollbar__color-active);
+  background-color: var(--layout__scroll-thumb-color-active);
 }
 /* Simple Input (Input text field) */
 .simple-input {
   color: var(--layout__primary-text-color);
-  background-color: #313131;
+  background-color: var(--layout__secondary-background);
 }
 /* Simple Disabled Text */
 .simple-disabled-text {
@@ -114,37 +141,37 @@ body {
 }
 /* Checkbox Dropdown */
 .checkbox-dropdown {
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
+  font-family: var(--layout__primary-font);
+  background-color: var(--layout__primary-background);
   color: var(--layout__primary-text-color);
 }
 .checkbox-dropdown__select-box {
-  background-color: var(--theme__background-color);
+  background-color: var(--layout__primary-background);
   color: var(--layout__primary-text-color);
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
 }
 .checkbox-dropdown__content {
-  background-color: var(--theme__background-color);
+  background-color: var(--layout__primary-background);
   color: var(--layout__primary-text-color);
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
 }
 .checkbox-dropdown__content label:hover {
   background-color: #1e90ff;
 }
 /* Input Dropdown */
 .input-dropdown {
-  font-family: var(--theme__font-family);
-  background-color: var(--theme__background-color);
+  font-family: var(--layout__primary-font);
+  background-color: var(--layout__primary-background);
   color: var(--layout__primary-text-color);
 }
 .input-dropdown__input-field__back {
-  background-color: #313131;
+  background-color: var(--layout__secondary-background);
   color: var(--layout__primary-text-color);
 }
 .input-dropdown__content {
-  background-color: #313131;
+  background-color: var(--layout__secondary-background);
   color: var(--layout__primary-text-color);
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
 }
 .input-dropdown__content label:hover,
 .input-dropdown__content label:focus {
@@ -152,7 +179,7 @@ body {
 }
 /* Log */
 .log {
-  color: #ffffff;
+  color: var(--layout__highlighted-text-color);
 }
 .log__time-stamp {
   color: #857df3;
@@ -182,43 +209,43 @@ body {
 
 /* ------ Main Layout ------ */
 .root {
-  background-color: var(--theme__title-bar__background-color);
+  background-color: var(--layout__tertiary-backround);
 }
 .main {
-  background-color: var(--theme__background-color);
+  background-color: var(--layout__primary-background);
 }
 
 
 /* ------ TitleBar ------ */
 .title-bar {
-  background-color: var(--theme__title-bar__background-color);
+  background-color: var(--layout__tertiary-backround);
 }
 /* Minimize Button */
 .title-bar__button-bar__min {
   background-image: url('../images/min.png');
 }
 .title-bar__button-bar__min:hover {
-  background-color: #242428;
+  background-color: var(--layout__four-background);
 }
 /* Maximize Button */
 .title-bar__button-bar__max {
   background-image: url('../images/max.png');
 }
 .title-bar__button-bar__max:hover {
-  background-color: #242428;
+  background-color: var(--layout__four-background);
 }
 /* Cross Button */
 .title-bar__button-bar__cross {
   background-image: url('../images/cross.png');
 }
 .title-bar__button-bar__cross:hover {
-  background-color: #eb4b4b;
+  background-color: var(--layout__title-bar-cross-color);
 }
 
 
 /* ------ Header ------ */
 .header {
-  background-color: var(--theme__header__background-color);
+  background-color: var(--layout__secondary-background);
 }
 .header__menu__item__link {
   cursor: pointer;
@@ -230,8 +257,11 @@ body {
   border-color: #d33682;
 }
 .header__search {
-  border: 1px solid var(--theme__search-bar__outline-color);
-  background-color: var(--theme__search-bar__background-color);
+  border: 1px solid var(--layout__primary-outline-color);
+  background-color: var(--layout__primary-background);
+}
+.header__search__input {
+  color: var(--layout__primary-text-color);
 }
 .header__search__icon .icon__use {
   fill: var(--layout__primary-text-color);
@@ -244,16 +274,16 @@ body {
   fill: #ccc;
 }
 .header__toggle-sidebar:hover .icon__use {
-  fill: #fff;
+  fill: var(--layout__highlighted-text-color);
 }
 .header__toggle-sidebar:active .icon__use {
-  fill: var(--color__aaa);
+  fill: var(--layout__secondary-text-color);
 }
 
 
 /* ------ Footer ------ */
 .footer {
-  background-color: var(--theme__footer__background-color);
+  background-color: var(--layout__secondary-background);
 }
 /* Scale Slider */
 .footer__scale-slider__inner {
@@ -264,10 +294,10 @@ body {
 .footer__scale-slider__icon {
   font-family: monospace;
   font-weight: bold;
-  color: var(--color__foot-slider-icon);
+  color: var(--layout__footer-scale-slider-icon-color);
 }
 .footer__scale-slider__icon--center {
-  background-color: var(--color__foot-slider-icon);
+  background-color: var(--layout__footer-scale-slider-icon-color);
 }
 .footer__scale-slider__input {
   background: none;
@@ -278,14 +308,14 @@ body {
 .footer__scale-slider__input::-webkit-slider-thumb {
   box-shadow: inset 0 0 calc(0.5 * var(--slider-size));
   border-radius: 50%;
-  background-color: var(--theme__slider__color);
+  background-color: var(--layout__slider-background);
   color: rgba(0, 0, 0, 0.05);
 }
 .footer__scale-slider__input::-webkit-slider-thumb:hover {
-  background-color: var(--theme__slider__color-hover);
+  background-color: var(--layout__slider-background-hover);
 }
 .footer__scale-slider__input::-webkit-slider-thumb:active {
-  background-color: var(--theme__slider__color-active);
+  background-color: var(--layout__slider-background-active);
 }
 
 
@@ -298,7 +328,7 @@ body {
   -webkit-mask-repeat: no-repeat;
   /* Cool colors yall */
   background:
-    linear-gradient(#00000000, var(--theme__background-color)),
+    linear-gradient(#00000000, var(--layout__primary-background)),
     linear-gradient(90deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3, #ff2400);
   background-size: var(--zoom) 100%;
   -webkit-animation: home-page__logo__slide 1200s linear infinite;
@@ -317,7 +347,7 @@ body {
 }
 /* HomePage Box - Upgrades */
 .home-page__box--upgrades .home-page__grayed-out {
-  color: var(--theme__text-disabled-color);
+  color: var(--layout__disabled-text-color);
 }
 /* HomePage Box - Extras */
 .home-page__box--extras span a {
@@ -327,7 +357,7 @@ body {
 
 /* ------ About ------ */
 .about-page__section__title {
-  background-color: #141417;
+  background-color: var(--layout__tertiary-backround);
 }
 /* Credits */
 .about-page__credits__tooltip {
@@ -335,7 +365,7 @@ body {
   background-color: #000000DD;
 }
 .about-page__credits__tooltip__note {
-  color: var(--theme__text-disabled-color);
+  color: var(--layout__disabled-text-color);
   font-style: italic;
 }
 .about-page__credits__tooltip__roles p {
@@ -352,18 +382,18 @@ body {
 
 /* ------ Browse ------ */
 .game-browser {
-  background-color: var(--theme__background-color);
+  background-color: var(--layout__primary-background);
 }
 /* Sidebar */
 .game-browser__sidebar {
-  background-color: var(--theme__browse-sidebar__background-color);
+  background-color: var(--layout__browse-sidebar-background);
 }
 .game-browser__sidebar__divider {
-  background-color: var(--theme__browse-sidebar__divider__background-color);
+  background-color: var(--layout__browse-sidebar-divider-background);
 }
 /* Browse-Right-Sidebar Additional-Application */
 .browse-right-sidebar__additional-application:nth-child(2n) {
-  background-color: #141417;
+  background-color: var(--layout__tertiary-backround);
 }
 /* BrowseSidebar Title-Row Buttons */
 .browse-right-sidebar__title-row__buttons .icon__use {
@@ -374,29 +404,36 @@ body {
 }
 /* BrowseSidebar Title-Row Delete-Game */
 .browse-right-sidebar__title-row__buttons__delete-game:hover .icon__use {
-  fill: #aa4b4b;
+  fill: var(--layout__warning-bright-color);
 }
 .browse-right-sidebar__title-row__buttons__delete-game--active:hover .icon__use {
-  fill: #8a1212;
+  fill: var(--layout__warning-medium-color);
 }
 /* BrowseSidebar Title-Row Remove-From-Playlist */
 .browse-right-sidebar__title-row__buttons__remove-from-playlist:hover .icon__use {
-  fill: #aa4b4b;
+  fill: var(--layout__warning-bright-color);
 }
 .browse-right-sidebar__title-row__buttons__remove-from-playlist--active:hover .icon__use {
-  fill: #8a1212;
+  fill: var(--layout__warning-medium-color);
 }
 /* BrowseSidebar Title-Row Edit */
 .browse-right-sidebar__title-row__buttons__edit-button:hover .icon__use {
-  fill: #5cb468;
+  fill: var(--layout__confirm-bright-color);
 }
 /* BrowseSidebar Title-Row Discard */
 .browse-right-sidebar__title-row__buttons__discard-button:hover .icon__use {
-  fill: #aa4b4b;
+  fill: var(--layout__warning-bright-color);
 }
 /* BrowseSidebar Title-Row Save */
 .browse-right-sidebar__title-row__buttons__save-button:hover .icon__use {
-  fill: #5cb468;
+  fill: var(--layout__confirm-bright-color);
+}
+/* Browse-Right-Sidebar Row - Additional Application */
+.browse-right-sidebar__additional-application__delete-button:hover .icon__use {
+  fill: var(--layout__warning-bright-color);
+}
+.browse-right-sidebar__additional-application__delete-button--active:hover .icon__use {
+  fill: var(--layout__confirm-bright-color);
 }
 /* Browse-Right-Sidebar Row - Screenshot */
 .browse-right-sidebar__row__screenshot__placeholder {
@@ -404,11 +441,11 @@ body {
   border-color: #818181;
 }
 .browse-right-sidebar__row__screenshot__placeholder p {
-  color: var(--theme__text-disabled-color);
+  color: var(--layout__disabled-text-color);
 }
 /* GameImageSplit */
 .game-image-split {
-  --inner-border-color: #313131;
+  --inner-border-color: var(--layout__secondary-background);
 }
 .game-image-split--hover {
   background-color: #575757;
@@ -423,71 +460,71 @@ body {
   border-left-color: var(--inner-border-color);
 }
 .game-image-split__buttons__remove-image:hover .icon__use {
-  fill: #aa4b4b;
+  fill: var(--layout__warning-bright-color);
 }
 .game-image-split__buttons__remove-image--active:hover .icon__use {
-  fill: #8a1212;
+  fill: var(--layout__warning-medium-color);
 }
 
 
 /* GameList Item */
 .game-list-item {
   list-style: none;
-  background-color: var(--theme__background-color);
-  color: var(--theme__game-item__color);
+  background-color: var(--layout__primary-background);
+  color: var(--layout__game-item-color);
 }
 .game-list-item--even {
-  background-color: var(--theme__game-list-item__background-color-even);
+  background-color: var(--layout__game-list-item-background-even);
 }
 .game-list-item:hover {
-  background-color: var(--theme__game-item__background-color-hover);
-  color: var(--theme__game-item__color-hover);
+  background-color: var(--layout__game-item-background-hover);
+  color: var(--layout__game-item-color-hover);
 }
 .game-list-item--selected {
-  background-color: var(--theme__game-item__background-color-selected);
-  color: var(--theme__game-item__color-selected);
+  background-color: var(--layout__game-item-background-selected);
+  color: var(--layout__game-item-color-selected);
 }
 .game-list-item--selected:hover {
-  background-color: var(--theme__game-item__background-color-selected-hover);
-  color: var(--theme__game-item__color-selected-hover);
+  background-color: var(--layout__game-item-background-selected-hover);
+  color: var(--layout__game-item-color-selected-hover);
 }
 /* GameList Item Thumb */
 .game-list-item__thumb {
-  image-rendering: var(--theme__game-item-thumb__image-rendering);
+  image-rendering: var(--layout__game-item-thumb-image-rendering);
 }
 
 
 /* GameGrid */
 .game-grid-item {
-  color: var(--theme__game-item__color);
+  color: var(--layout__game-item-color);
 }
 .game-grid-item:hover {
-  background-color: var(--theme__game-item__background-color-hover);
-  color: var(--theme__game-item__color-hover);
+  background-color: var(--layout__game-item-background-hover);
+  color: var(--layout__game-item-color-hover);
 }
 .game-grid-item--selected {
-  background-color: var(--theme__game-item__background-color-selected);
-  color: var(--theme__game-item__color-selected);
+  background-color: var(--layout__game-item-background-selected);
+  color: var(--layout__game-item-color-selected);
 }
 .game-grid-item--selected:hover {
-  background-color: var(--theme__game-item__background-color-selected-hover);
-  color: var(--theme__game-item__color-selected-hover);
+  background-color: var(--layout__game-item-background-selected-hover);
+  color: var(--layout__game-item-color-selected-hover);
 }
 .game-grid-item__thumb__image {
   border-radius: 0.2em;
-  background-color: #242428;
-  border-color: #141417;
+  background-color: var(--layout__four-background);
+  border-color: var(--layout__tertiary-backround);
   box-shadow: 0px 2px 4px 0px #09090a;
-  image-rendering: var(--theme__game-item-thumb__image-rendering);
+  image-rendering: var(--layout__game-item-thumb-image-rendering);
 }
 
 /* Playlist-List-Item */
 .playlist-list-item {
-  background-color: var(--theme__background-color);
-  color: var(--color__aaa);
+  background-color: var(--layout__primary-background);
+  color: var(--layout__secondary-text-color);
 }
 .playlist-list-item:nth-child(2n) {
-  background-color: var(--theme__playlist-list-item-even__background-color);
+  background-color: var(--layout__playlist-list-item-even-background);
 }
 .playlist-list-item:hover,
 .playlist-list-item.playlist-list-item--drag-over {
@@ -508,7 +545,7 @@ body {
 }
 /* Playlist-List-Item Head */
 .playlist-list-item__head {
-  --color: var(--color__aaa);
+  --color: var(--layout__secondary-text-color);
   color: var(--color);
 }
 .playlist-list-item__head:hover,
@@ -524,19 +561,19 @@ body {
 }
 .playlist-list-item--editing .playlist-list-item__content {
   background-color: #1c291b;
-  color: var(--color__playlist-description-while-edititng);
+  color: var(--layout__highlighted-text-color);
 }
 .playlist-list-item__content__description-edit {
   background-color: #3a5637;
 }
 /* Playlist-List-Fake-Item */
 .playlist-list-fake-item {
-  background-color: var(--theme__playlist-list-fake-item__background-color);
-  --color: #aaaaaa;
+  background-color: var(--layout__playlist-list-fake-even-background);
+  --color: var(--layout__secondary-text-color);
 }
 .playlist-list-fake-item:hover {
   background-color: #343438;
-  --color: #ffffff;
+  --color: var(--layout__highlighted-text-color);
 }
 .playlist-list-fake-item__inner .icon__use {
   fill: var(--color);
@@ -556,8 +593,8 @@ body {
 /** ------ Config ------ */
 /* Setting */
 .setting__body {
-  background-color: #242428;
-  border-color: #141417;
+  background-color: var(--layout__four-background);
+  border-color: var(--layout__tertiary-backround);
   box-shadow: 0px 2px 4px 0px #09090a;
 }
 /* Setting Row */
@@ -565,27 +602,27 @@ body {
   padding: 0.75em;
 }
 .setting__row:not(:first-child) {
-  border-top-color: #141417;
+  border-top-color: var(--layout__tertiary-backround);
 }
 /* Setting Row Content - FilePoint Path */
 .setting__row__content--filepath-path .flashpoint-path__input {
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
 }
 .setting__row__content--filepath-path .flashpoint-path__input--valid {
-  background-color: #009600;
+  background-color: var(--layout__valid-color);
 }
 .setting__row__content--filepath-path .flashpoint-path__input--invalid {
-  background-color: #840000;
+  background-color: var(--layout__invalid-color);
 }
 .setting__row__content--filepath-path .flashpoint-path__input input[type="text"] {
   color: var(--layout__primary-text-color);
 }
 /* Setting Row Content - Input Field */
 .setting__row__content--input-field > :first-child > * {
-  border-color: var(--theme__search-bar__outline-color);
+  border-color: var(--layout__primary-outline-color);
 }
 /* Setting Row Content - Theme Input Field */
 .setting__row__content--theme-input-field label:last-child {
   /* Change the color of the "No Theme" suggestion in the drop-down list. */
-  color: var(--color__no-theme-suggestion);
+  color: var(--layout__no-theme-suggestion-color);
 }

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -13,9 +13,7 @@
   /* Font */
   --layout__primary-font: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
   /* Confirm */
-  /*--layout__confirm-dark-color:   #5cb468;
-  --layout__confirm-medium-color: #5cb468;*/
-  --layout__confirm-bright-color: #5cb468;
+  --layout__confirm-color: #5cb468;
   /* Warning */
   --layout__warning-dark-color:   #5a1010;
   --layout__warning-medium-color: #731919;
@@ -24,44 +22,44 @@
   --layout__valid-color:   #009600;
   --layout__invalid-color: #840000;
   /* Text Color */
-  --layout__primary-text-color: #f1f1f1;
-  --layout__secondary-text-color: #aaaaaa;
+  --layout__primary-text-color:     #f1f1f1;
+  --layout__secondary-text-color:   #aaaaaa;
   --layout__highlighted-text-color: #ffffff;
-  --layout__disabled-text-color: #9b9b9b;
+  --layout__disabled-text-color:    #9b9b9b;
   /* Background */
-  --layout__primary-background: #1b1b1c;
+  --layout__primary-background:   #1b1b1c;
   --layout__secondary-background: #2d2d30;
-  --layout__tertiary-backround: #141417;
-  --layout__four-background: #242428;
+  --layout__tertiary-background:   #141417;
+  --layout__four-background:      #242428;
   /* Outline Color */
   --layout__primary-outline-color: #47474d;
   /* Scrollbar */
-  --layout__scroll-thumb-color: #585858;
-  --layout__scroll-thumb-color-hover: #505050;
+  --layout__scroll-thumb-color:        #585858;
+  --layout__scroll-thumb-color-hover:  #505050;
   --layout__scroll-thumb-color-active: #404040;
   /* Slider */
-  --layout__slider-background: #4d4f55;
-  --layout__slider-background-hover: #43454b;
+  --layout__slider-background:        #4d4f55;
+  --layout__slider-background-hover:  #43454b;
   --layout__slider-background-active: #2e2f33;
   /* Game Item */
   --layout__game-item-color: var(--layout__secondary-text-color);
   --layout__game-item-color-hover: var(--layout__primary-text-color);
-  --layout__game-item-color-selected: #cecece;
+  --layout__game-item-color-selected:            #cecece;
   --layout__game-item-color-selected-hover: var(--layout__game-item-color-hover);
-  --layout__game-list-item-background-even: #1e1e1f; /* Only used in "list" mode. */
-  --layout__game-item-background-hover: #3c3c41;
-  --layout__game-item-background-selected: #791c76;
+  --layout__game-list-item-background-even:      #1e1e1f; /* Only used in "list" mode. */
+  --layout__game-item-background-hover:          #3c3c41;
+  --layout__game-item-background-selected:       #791c76;
   --layout__game-item-background-selected-hover: #a72aa2;
-  --layout__game-item-thumb-image-rendering: normal; /* Used to set the "image-rendering" of the thumbnail. */
+  --layout__game-item-thumb-image-rendering:       normal; /* Used to set the "image-rendering" of the thumbnail. */
   /* Browse Sidebar */
-  --layout__browse-sidebar-background: #181819;
+  --layout__browse-sidebar-background:         #181819;
   --layout__browse-sidebar-divider-background: #131313;
   /* Playlist List */
   --layout__playlist-list-item-even-background: #1e1e1f;
   --layout__playlist-list-fake-even-background: #19191b;
   /* Misc */
-  --layout__title-bar-cross-color: #eb4b4b;
-  --layout__no-theme-suggestion-color: #bfbfbf;
+  --layout__title-bar-cross-color:          #eb4b4b;
+  --layout__no-theme-suggestion-color:      #bfbfbf;
   --layout__footer-scale-slider-icon-color: #0f1010;
 }
 
@@ -209,7 +207,7 @@ body {
 
 /* ------ Main Layout ------ */
 .root {
-  background-color: var(--layout__tertiary-backround);
+  background-color: var(--layout__tertiary-background);
 }
 .main {
   background-color: var(--layout__primary-background);
@@ -218,7 +216,7 @@ body {
 
 /* ------ TitleBar ------ */
 .title-bar {
-  background-color: var(--layout__tertiary-backround);
+  background-color: var(--layout__tertiary-background);
 }
 /* Minimize Button */
 .title-bar__button-bar__min {
@@ -357,7 +355,7 @@ body {
 
 /* ------ About ------ */
 .about-page__section__title {
-  background-color: var(--layout__tertiary-backround);
+  background-color: var(--layout__tertiary-background);
 }
 /* Credits */
 .about-page__credits__tooltip {
@@ -393,7 +391,7 @@ body {
 }
 /* Browse-Right-Sidebar Additional-Application */
 .browse-right-sidebar__additional-application:nth-child(2n) {
-  background-color: var(--layout__tertiary-backround);
+  background-color: var(--layout__tertiary-background);
 }
 /* BrowseSidebar Title-Row Buttons */
 .browse-right-sidebar__title-row__buttons .icon__use {
@@ -418,7 +416,7 @@ body {
 }
 /* BrowseSidebar Title-Row Edit */
 .browse-right-sidebar__title-row__buttons__edit-button:hover .icon__use {
-  fill: var(--layout__confirm-bright-color);
+  fill: var(--layout__confirm-color);
 }
 /* BrowseSidebar Title-Row Discard */
 .browse-right-sidebar__title-row__buttons__discard-button:hover .icon__use {
@@ -426,14 +424,14 @@ body {
 }
 /* BrowseSidebar Title-Row Save */
 .browse-right-sidebar__title-row__buttons__save-button:hover .icon__use {
-  fill: var(--layout__confirm-bright-color);
+  fill: var(--layout__confirm-color);
 }
 /* Browse-Right-Sidebar Row - Additional Application */
 .browse-right-sidebar__additional-application__delete-button:hover .icon__use {
   fill: var(--layout__warning-bright-color);
 }
 .browse-right-sidebar__additional-application__delete-button--active:hover .icon__use {
-  fill: var(--layout__confirm-bright-color);
+  fill: var(--layout__confirm-color);
 }
 /* Browse-Right-Sidebar Row - Screenshot */
 .browse-right-sidebar__row__screenshot__placeholder {
@@ -513,7 +511,7 @@ body {
 .game-grid-item__thumb__image {
   border-radius: 0.2em;
   background-color: var(--layout__four-background);
-  border-color: var(--layout__tertiary-backround);
+  border-color: var(--layout__tertiary-background);
   box-shadow: 0px 2px 4px 0px #09090a;
   image-rendering: var(--layout__game-item-thumb-image-rendering);
 }
@@ -594,7 +592,7 @@ body {
 /* Setting */
 .setting__body {
   background-color: var(--layout__four-background);
-  border-color: var(--layout__tertiary-backround);
+  border-color: var(--layout__tertiary-background);
   box-shadow: 0px 2px 4px 0px #09090a;
 }
 /* Setting Row */
@@ -602,7 +600,7 @@ body {
   padding: 0.75em;
 }
 .setting__row:not(:first-child) {
-  border-top-color: var(--layout__tertiary-backround);
+  border-top-color: var(--layout__tertiary-background);
 }
 /* Setting Row Content - FilePoint Path */
 .setting__row__content--filepath-path .flashpoint-path__input {

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -27,10 +27,10 @@
   --layout__highlighted-text-color: #ffffff;
   --layout__disabled-text-color:    #9b9b9b;
   /* Background */
-  --layout__primary-background:   #1b1b1c;
-  --layout__secondary-background: #2d2d30;
+  --layout__primary-background:    #1b1b1c;
+  --layout__secondary-background:  #2d2d30;
   --layout__tertiary-background:   #141417;
-  --layout__four-background:      #242428;
+  --layout__quaternary-background: #242428;
   /* Outline Color */
   --layout__primary-outline-color: #47474d;
   /* Scrollbar */
@@ -51,16 +51,61 @@
   --layout__game-item-background-selected:       #791c76;
   --layout__game-item-background-selected-hover: #a72aa2;
   --layout__game-item-thumb-image-rendering:       normal; /* Used to set the "image-rendering" of the thumbnail. */
-  /* Browse Sidebar */
+  /* Browse Sidebar(s) */
   --layout__browse-sidebar-background:         #181819;
   --layout__browse-sidebar-divider-background: #131313;
+  /* Right Browse Sidebar */
+  --layout__browse-right-sidebar-screenshot-placeholder-background: #1b1b1b;
+  --layout__browse-right-sidebar-screenshot-placeholder-border:     #818181;
   /* Playlist List */
-  --layout__playlist-list-item-even-background: #1e1e1f;
-  --layout__playlist-list-fake-even-background: #19191b;
+  --layout__playlist-list-item-even-background:                #1e1e1f;
+  --layout__playlist-list-fake-even-background:                #19191b;
+  --layout__playlist-list-item-content-background:             #242425;
+  --layout__playlist-list-item-hover-color:                    #e6e6e6;
+  --layout__playlist-list-fake-hover-background:               #343438;
+  --layout__playlist-list-item-drag-over-background:           #3c3c41;
+  --layout__playlist-list-item-drag-over-border:               #818181;
+  --layout__playlist-list-item-editing-odd-background:         #151f14;
+  --layout__playlist-list-item-editing-even-background:        #192519;
+  --layout__playlist-list-item-editing-drag-over-background:   #20301f;
+  --layout__playlist-list-item-editing-content-background:     #1c291b;
+  --layout__playlist-list-item-editing-description-background: #3a5637;
+  /* Game Image Split */
+  --layout__game-image-split-hover-color:    #575757;
+  --layout__game-image-split-disabled-color: #141414;
+  /* Home Page */
+  --layout__home-page-box-border:     #3f3f3f;
+  --layout__home-page-box-background: #252525;
+  /* Log (at the Log Page) */
+  --layout__log-time-stamp:                 #857df3;
+  --layout__log-source:                     #d4d4d4;
+  --layout__log-source-background-services: #8d8d8d;
+  --layout__log-source-game-launcher:       #ffd900;
+  --layout__log-source-redirector:          #00ffff;
+  --layout__log-source-router:              #00ff00;
+  /* Credits */
+  --layout__credits-tooltip-border:           #000000;
+  --layout__credits-tooltip-background:       #000000DD;
+  --layout__credits-tooltip-roles-background: #000000;
+  /* Log Page */
+  --layout__log-page-bar-background: #222222;
+  /* Developer Page */
+  --layout__developer-page-log-background: #313133;
+  --layout__developer-page-log-border:     #353535;
+  /* Simple Button */
+  --layout__simple-button-background: #434346;
+  --layout__simple-button-border: #6f6f75;
+  /* Header Menu Item */
+  --layout__header-menu-item-hover-background: #3c2d4b;
+  --layout__header-menu-item-hover-border: #d33682;
   /* Misc */
-  --layout__title-bar-cross-color:          #eb4b4b;
-  --layout__no-theme-suggestion-color:      #bfbfbf;
-  --layout__footer-scale-slider-icon-color: #0f1010;
+  --layout__title-bar-cross-color:                 #eb4b4b;
+  --layout__no-theme-suggestion-color:             #bfbfbf;
+  --layout__footer-scale-slider-icon-color:        #0f1010;
+  --layout__footer-scale-slider-background:        #353838;
+  --layout__icon-button-hover-fill:                #b1b1b1; /* Color of "icon buttons" while the cursor is hovering over them. */
+  --layout__toggle-sidebar-fill:                   #cccccc;
+  --layout__drop-down-content-background-selected: #1e90ff;
 }
 
 body {
@@ -88,8 +133,8 @@ body {
   color: var(--layout__primary-text-color);
 }
 .simple-button:hover {
-  background-color: #434346;
-  border-color: #6f6f75;
+  background-color: var(--layout__simple-button-background);
+  border-color: var(--layout__simple-button-border);
 }
 .simple-button:disabled {
   color: var(--layout__disabled-text-color);
@@ -154,7 +199,7 @@ body {
   border-color: var(--layout__primary-outline-color);
 }
 .checkbox-dropdown__content label:hover {
-  background-color: #1e90ff;
+  background-color: var(--layout__drop-down-content-background-selected);
 }
 /* Input Dropdown */
 .input-dropdown {
@@ -173,29 +218,30 @@ body {
 }
 .input-dropdown__content label:hover,
 .input-dropdown__content label:focus {
-  background-color: #1e90ff;
+  background-color: var(--layout__drop-down-content-background-selected);
 }
 /* Log */
 .log {
   color: var(--layout__highlighted-text-color);
 }
 .log__time-stamp {
-  color: #857df3;
+  color: var(layout__log-time-stamp);
 }
 .log__source {
-  color: #d4d4d4; /* Default color of sources, used on the unknown/unspecified sources */
+  /* Default color of sources, used on the unknown/unspecified sources */
+  color: var(--layout__log-source);
 }
 .log__source--background-services {
-  color: #8d8d8d;
+  color: var(--layout__log-source-background-services);
 }
 .log__source--game-launcher {
-  color: #ffd900;
-}
-.log__source--router {
-  color: #00ff00;
+  color: var(--layout__log-source-game-launcher);
 }
 .log__source--redirector {
-  color: #00ffff;
+  color: var(--layout__log-source-redirector);
+}
+.log__source--router {
+  color: var(--layout__log-source-router);
 }
 
 
@@ -223,14 +269,14 @@ body {
   background-image: url('../images/min.png');
 }
 .title-bar__button-bar__min:hover {
-  background-color: var(--layout__four-background);
+  background-color: var(--layout__quaternary-background);
 }
 /* Maximize Button */
 .title-bar__button-bar__max {
   background-image: url('../images/max.png');
 }
 .title-bar__button-bar__max:hover {
-  background-color: var(--layout__four-background);
+  background-color: var(--layout__quaternary-background);
 }
 /* Cross Button */
 .title-bar__button-bar__cross {
@@ -251,8 +297,8 @@ body {
   color: var(--layout__primary-text-color);
 }
 .header__menu__item__link:hover {
-  background-color: #3c2d4b;
-  border-color: #d33682;
+  background-color: var(--layout__header-menu-item-hover-background);
+  border-color: var(--layout__header-menu-item-hover-border);
 }
 .header__search {
   border: 1px solid var(--layout__primary-outline-color);
@@ -265,11 +311,11 @@ body {
   fill: var(--layout__primary-text-color);
 }
 .header__search__icon:hover .icon__use--circle-x {
-  fill: #b1b1b1;
+  fill: var(--layout__icon-button-hover-fill);
 }
 /* Header Toggle-Sidebar */
 .header__toggle-sidebar .icon__use {
-  fill: #ccc;
+  fill: var(--layout__toggle-sidebar-fill);
 }
 .header__toggle-sidebar:hover .icon__use {
   fill: var(--layout__highlighted-text-color);
@@ -285,7 +331,7 @@ body {
 }
 /* Scale Slider */
 .footer__scale-slider__inner {
-  background-color: #353838;
+  background-color: var(--layout__footer-scale-slider-background);
   box-shadow: inset 0 0 calc(0.5 * var(--slider-size)) rgba(0, 0, 0, 0.05);
   border-radius: calc(0.5 * var(--slider-size));
 }
@@ -326,7 +372,7 @@ body {
   -webkit-mask-repeat: no-repeat;
   /* Cool colors yall */
   background:
-    linear-gradient(#00000000, var(--layout__primary-background)),
+    linear-gradient(rgba(0, 0, 0, 0), var(--layout__primary-background)),
     linear-gradient(90deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3, #ff2400);
   background-size: var(--zoom) 100%;
   -webkit-animation: home-page__logo__slide 1200s linear infinite;
@@ -337,11 +383,11 @@ body {
 }
 /* HomePage Box */
 .home-page__box {
-  border-color: #3f3f3f;
-  background-color: #252525;
+  border-color: var(--layout__home-page-box-border);
+  background-color: var(--layout__home-page-box-background);
 }
 .home-page__box__head {
-  border-bottom-color: #3f3f3f;
+  border-bottom-color: var(--layout__home-page-box-border);
 }
 /* HomePage Box - Upgrades */
 .home-page__box--upgrades .home-page__grayed-out {
@@ -359,22 +405,22 @@ body {
 }
 /* Credits */
 .about-page__credits__tooltip {
-  border-color: #000000;
-  background-color: #000000DD;
+  border-color: var(--layout__credits-tooltip-border);
+  background-color: var(--layout__credits-tooltip-background);
 }
 .about-page__credits__tooltip__note {
   color: var(--layout__disabled-text-color);
   font-style: italic;
 }
 .about-page__credits__tooltip__roles p {
-  background-color: #000000;
+  background-color: var(--layout__credits-tooltip-roles-background);
 }
 
 
 /* ------ Log ------ */
 /* Log-Page Bar */
 .log-page__bar {
-  background-color: #222222;
+  background-color: var(--layout__log-page-bar-background);
 }
 
 
@@ -398,7 +444,7 @@ body {
   fill: var(--layout__primary-text-color);
 }
 .browse-right-sidebar__title-row__buttons :hover .icon__use {
-  fill: #b1b1b1;
+  fill: var(--layout__icon-button-hover-fill);
 }
 /* BrowseSidebar Title-Row Delete-Game */
 .browse-right-sidebar__title-row__buttons__delete-game:hover .icon__use {
@@ -435,8 +481,8 @@ body {
 }
 /* Browse-Right-Sidebar Row - Screenshot */
 .browse-right-sidebar__row__screenshot__placeholder {
-  background-color: #1b1b1b;
-  border-color: #818181;
+  background-color: var(--layout__browse-right-sidebar-screenshot-placeholder-background);
+  border-color: var(--layout__browse-right-sidebar-screenshot-placeholder-border);
 }
 .browse-right-sidebar__row__screenshot__placeholder p {
   color: var(--layout__disabled-text-color);
@@ -446,10 +492,10 @@ body {
   --inner-border-color: var(--layout__secondary-background);
 }
 .game-image-split--hover {
-  background-color: #575757;
+  background-color: var(--layout__game-image-split-hover-color);
 }
 .game-image-split--disabled {
-  background-color: #141414;
+  background-color: var(--layout__game-image-split-disabled-color);
 }
 .game-image-split:first-child {
   border-right-color: var(--inner-border-color);
@@ -510,7 +556,7 @@ body {
 }
 .game-grid-item__thumb__image {
   border-radius: 0.2em;
-  background-color: var(--layout__four-background);
+  background-color: var(--layout__quaternary-background);
   border-color: var(--layout__tertiary-background);
   box-shadow: 0px 2px 4px 0px #09090a;
   image-rendering: var(--layout__game-item-thumb-image-rendering);
@@ -526,20 +572,20 @@ body {
 }
 .playlist-list-item:hover,
 .playlist-list-item.playlist-list-item--drag-over {
-  background-color: #3c3c41;
+  background-color: var(--layout__playlist-list-item-drag-over-background);
 }
 .playlist-list-item--editing {
-  background-color: #151f14;
+  background-color: var(--layout__playlist-list-item-editing-odd-background);
 }
 .playlist-list-item--editing:nth-child(2n) {
-  background-color: #192519;
+  background-color: var(--layout__playlist-list-item-editing-even-background);
 }
 .playlist-list-item--editing:hover,
 .playlist-list-item--editing.playlist-list-item--drag-over {
-  background-color: #20301f;
+  background-color: var(--layout__playlist-list-item-editing-drag-over-background);
 }
 .playlist-list-item--drag-over .playlist-list-item__drag-overlay {
-  border-color: #818181;
+  border-color: var(--layout__playlist-list-item-drag-over-border);
 }
 /* Playlist-List-Item Head */
 .playlist-list-item__head {
@@ -548,21 +594,21 @@ body {
 }
 .playlist-list-item__head:hover,
 .playlist-list-item--drag-over .playlist-list-item__head {
-  --color: #e6e6e6;
+  --color: var(--layout__playlist-list-item-hover-color);
 }
 .playlist-list-item__head__icon__no-image__icon .icon__use {
   fill: var(--color);
 }
 /* Playlist-List-Item Content */
 .playlist-list-item__content {
-  background-color: #242425;
+  background-color: var(--layout__playlist-list-item-content-background);
 }
 .playlist-list-item--editing .playlist-list-item__content {
-  background-color: #1c291b;
+  background-color: var(--layout__playlist-list-item-editing-content-background);
   color: var(--layout__highlighted-text-color);
 }
 .playlist-list-item__content__description-edit {
-  background-color: #3a5637;
+  background-color: var(--layout__playlist-list-item-editing-description-background);
 }
 /* Playlist-List-Fake-Item */
 .playlist-list-fake-item {
@@ -570,7 +616,7 @@ body {
   --color: var(--layout__secondary-text-color);
 }
 .playlist-list-fake-item:hover {
-  background-color: #343438;
+  background-color: var(--layout__playlist-list-fake-hover-background);
   --color: var(--layout__highlighted-text-color);
 }
 .playlist-list-fake-item__inner .icon__use {
@@ -583,15 +629,15 @@ body {
 
 /** ------ Developer ------ */
 .developer-page__log {
-  background-color: #313133;
-  border-color: #353535;
+  background-color: var(--layout__developer-page-log-background);
+  border-color: var(--layout__developer-page-log-border);
 }
 
 
 /** ------ Config ------ */
 /* Setting */
 .setting__body {
-  background-color: var(--layout__four-background);
+  background-color: var(--layout__quaternary-background);
   border-color: var(--layout__tertiary-background);
   box-shadow: 0px 2px 4px 0px #09090a;
 }
@@ -616,7 +662,8 @@ body {
   color: var(--layout__primary-text-color);
 }
 /* Setting Row Content - Input Field */
-.setting__row__content--input-field > :first-child > * {
+.setting__row__content--input-field .input-dropdown__input-field,
+.setting__row__content--input-field .input-dropdown__content {
   border-color: var(--layout__primary-outline-color);
 }
 /* Setting Row Content - Theme Input Field */

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -1,0 +1,590 @@
+/* ------ General ------ */
+:root {
+  /* ------- Layout Variables ------- */
+  --color__aaa: var(--layout__secondary-text-color);
+  --color__playlist-description-while-edititng: #ffffff;
+  --color__no-theme-suggestion: #bfbfbf;
+  /* Text */
+  --layout__primary-text-color: #f1f1f1;
+  --layout__secondary-text-color: #aaaaaa;
+  --layout__highlighted-text-color: #ffffff;
+  --layout__disabled-text-color: #9b9b9b;
+  /* Background */
+  --layout__primary-background: #1b1b1c;
+  --layout__secondary-background: #2d2d30;
+  /* Theme Variables */
+  --theme__font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+  --theme__text-disabled-color: #9b9b9b;
+  --theme__background-color: #1b1b1c;
+  --theme__search-bar__background-color: #1b1b1d;
+  --theme__search-bar__outline-color: #47474d;
+  --theme__title-bar__background-color: #141417;
+  --theme__scrollbar__color: #585858;
+  --theme__scrollbar__color-hover: #505050;
+  --theme__scrollbar__color-active: #404040;
+  --theme__slider__color: #4d4f55;
+  --theme__slider__color-hover: #43454b;
+  --theme__slider__color-active: #2e2f33;
+  --theme__browse-sidebar__background-color: #181819;
+  --theme__browse-sidebar__divider__background-color: #131313;
+  --theme__header__background-color: #2d2d30;
+  --theme__footer__background-color: #2a2a2b;
+  --theme__playlist-list-item-even__background-color: #1e1e1f;
+  --theme__playlist-list-fake-item__background-color: #19191b;
+  --theme__game-item__color: #aaaaaa;
+  --theme__game-item__color-hover: #e6e6e6;
+  --theme__game-item__color-selected: #cecece;
+  --theme__game-item__color-selected-hover: #e6e6e6;
+  --theme__game-item__background-color-hover: #3c3c41;
+  --theme__game-item__background-color-selected: #791c76;
+  --theme__game-item__background-color-selected-hover: #a72aa2;
+  --theme__game-list-item__background-color-even: #1e1e1f;
+  --theme__game-item-thumb__image-rendering: normal;
+  /* Pimp */
+  color: var(--layout__primary-text-color);
+}
+
+body {
+  background-color: var(--theme__background-color);
+  font-family: var(--theme__font-family);
+}
+
+:link {
+  color: var(--layout__highlighted-text-color);
+}
+
+
+/* ------ Icons ------ */
+.icon__use {
+  fill: var(--layout__highlighted-text-color);
+}
+
+
+/* ------ Generic & Re-usable ------ */
+/* Simple Button */
+.simple-button {
+  background-color: #2d2d30;
+  border-color: var(--theme__search-bar__outline-color);
+  color: var(--layout__primary-text-color);
+}
+.simple-button:hover {
+  background-color: #434346;
+  border-color: #6f6f75;
+}
+.simple-button:disabled {
+  color: var(--theme__text-disabled-color);
+}
+.simple-button--red {
+  background-color: #5a1010;
+  border-color: #731919;
+}
+.simple-button--red:hover {
+  background-color: #731616;
+  border-color: #a22020;
+}
+/* Simple Selector */
+.simple-selector {
+  border-color: var(--theme__search-bar__outline-color);
+  /* Pimp */
+  font-family: var(--theme__font-family);
+  background-color: var(--theme__background-color);
+  color: var(--layout__primary-text-color);
+}
+/* Simple Scroll(bar) */
+.simple-scroll::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 calc(0.25 * var(--scrollbar-size)) rgba(0, 0, 0, 0.25);
+  background-color: rgba(0, 0, 0, 0.085);
+  border-radius: calc(0.5 * var(--scrollbar-size));
+}
+.simple-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: var(--theme__scrollbar__color-hover);
+}
+.simple-scroll::-webkit-scrollbar-thumb:active {
+  background-color: var(--theme__scrollbar__color-active);
+}
+/* Simple Input (Input text field) */
+.simple-input {
+  color: var(--layout__primary-text-color);
+  background-color: #313131;
+}
+/* Simple Disabled Text */
+.simple-disabled-text {
+  color: var(--layout__disabled-text-color);
+}
+/* Checkbox Dropdown */
+.checkbox-dropdown {
+  font-family: var(--theme__font-family);
+  background-color: var(--theme__background-color);
+  color: var(--layout__primary-text-color);
+}
+.checkbox-dropdown__select-box {
+  background-color: var(--theme__background-color);
+  color: var(--layout__primary-text-color);
+  border-color: var(--theme__search-bar__outline-color);
+}
+.checkbox-dropdown__content {
+  background-color: var(--theme__background-color);
+  color: var(--layout__primary-text-color);
+  border-color: var(--theme__search-bar__outline-color);
+}
+.checkbox-dropdown__content label:hover {
+  background-color: #1e90ff;
+}
+/* Input Dropdown */
+.input-dropdown {
+  font-family: var(--theme__font-family);
+  background-color: var(--theme__background-color);
+  color: var(--layout__primary-text-color);
+}
+.input-dropdown__input-field__back {
+  background-color: #313131;
+  color: var(--layout__primary-text-color);
+}
+.input-dropdown__content {
+  background-color: #313131;
+  color: var(--layout__primary-text-color);
+  border-color: var(--theme__search-bar__outline-color);
+}
+.input-dropdown__content label:hover,
+.input-dropdown__content label:focus {
+  background-color: #1e90ff;
+}
+/* Log */
+.log {
+  color: #ffffff;
+}
+.log__time-stamp {
+  color: #857df3;
+}
+.log__source {
+  color: #d4d4d4; /* Default color of sources, used on the unknown/unspecified sources */
+}
+.log__source--background-services {
+  color: #8d8d8d;
+}
+.log__source--game-launcher {
+  color: #ffd900;
+}
+.log__source--router {
+  color: #00ff00;
+}
+.log__source--redirector {
+  color: #00ffff;
+}
+
+
+/* ------ Image Preview ------ */
+.image-preview {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+
+/* ------ Main Layout ------ */
+.root {
+  background-color: var(--theme__title-bar__background-color);
+}
+.main {
+  background-color: var(--theme__background-color);
+}
+
+
+/* ------ TitleBar ------ */
+.title-bar {
+  background-color: var(--theme__title-bar__background-color);
+}
+/* Minimize Button */
+.title-bar__button-bar__min {
+  background-image: url('../images/min.png');
+}
+.title-bar__button-bar__min:hover {
+  background-color: #242428;
+}
+/* Maximize Button */
+.title-bar__button-bar__max {
+  background-image: url('../images/max.png');
+}
+.title-bar__button-bar__max:hover {
+  background-color: #242428;
+}
+/* Cross Button */
+.title-bar__button-bar__cross {
+  background-image: url('../images/cross.png');
+}
+.title-bar__button-bar__cross:hover {
+  background-color: #eb4b4b;
+}
+
+
+/* ------ Header ------ */
+.header {
+  background-color: var(--theme__header__background-color);
+}
+.header__menu__item__link {
+  cursor: pointer;
+  text-decoration: none;
+  color: var(--layout__primary-text-color);
+}
+.header__menu__item__link:hover {
+  background-color: #3c2d4b;
+  border-color: #d33682;
+}
+.header__search {
+  border: 1px solid var(--theme__search-bar__outline-color);
+  background-color: var(--theme__search-bar__background-color);
+}
+.header__search__icon .icon__use {
+  fill: var(--layout__primary-text-color);
+}
+.header__search__icon:hover .icon__use--circle-x {
+  fill: #b1b1b1;
+}
+/* Header Toggle-Sidebar */
+.header__toggle-sidebar .icon__use {
+  fill: #ccc;
+}
+.header__toggle-sidebar:hover .icon__use {
+  fill: #fff;
+}
+.header__toggle-sidebar:active .icon__use {
+  fill: var(--color__aaa);
+}
+
+
+/* ------ Footer ------ */
+.footer {
+  background-color: var(--theme__footer__background-color);
+}
+/* Scale Slider */
+.footer__scale-slider__inner {
+  background-color: #353838;
+  box-shadow: inset 0 0 calc(0.5 * var(--slider-size)) rgba(0, 0, 0, 0.05);
+  border-radius: calc(0.5 * var(--slider-size));
+}
+.footer__scale-slider__icon {
+  font-family: monospace;
+  font-weight: bold;
+  color: var(color__foot-slider-icon);
+}
+.footer__scale-slider__icon--center {
+  background-color: var(color__foot-slider-icon);
+}
+.footer__scale-slider__input {
+  background: none;
+}
+.footer__scale-slider__input::-webkit-slider-runnable-track {
+  background: none;
+}
+.footer__scale-slider__input::-webkit-slider-thumb {
+  box-shadow: inset 0 0 calc(0.5 * var(--slider-size));
+  border-radius: 50%;
+  background-color: var(--theme__slider__color);
+  color: rgba(0, 0, 0, 0.05);
+}
+.footer__scale-slider__input::-webkit-slider-thumb:hover {
+  background-color: var(--theme__slider__color-hover);
+}
+.footer__scale-slider__input::-webkit-slider-thumb:active {
+  background-color: var(--theme__slider__color-active);
+}
+
+
+/* ------ Home ------ */
+/* Logo */
+.home-page__logo__image {
+  /* Mask the background color with the FP logo */
+  -webkit-mask: url('../images/logo-solid.svg');
+  -webkit-mask-size: var(--size);
+  -webkit-mask-repeat: no-repeat;
+  /* Cool colors yall */
+  background:
+    linear-gradient(#00000000, var(--theme__background-color)),
+    linear-gradient(90deg, #ff2400, #e81d1d, #e8b71d, #e3e81d, #1de840, #1ddde8, #2b1de8, #dd00f3, #ff2400);
+  background-size: var(--zoom) 100%;
+  -webkit-animation: home-page__logo__slide 1200s linear infinite;
+}
+@-webkit-keyframes home-page__logo__slide {
+     0% { background-position-x:          0%; }
+   100% { background-position-x: var(--zoom); }
+}
+/* HomePage Box */
+.home-page__box {
+  border-color: #3f3f3f;
+  background-color: #252525;
+}
+.home-page__box__head {
+  border-bottom-color: #3f3f3f;
+}
+/* HomePage Box - Upgrades */
+.home-page__box--upgrades .home-page__grayed-out {
+  color: var(--theme__text-disabled-color);
+}
+/* HomePage Box - Extras */
+.home-page__box--extras span a {
+  text-decoration: none;
+}
+
+
+/* ------ About ------ */
+.about-page__section__title {
+  background-color: #141417;
+}
+/* Credits */
+.about-page__credits__tooltip {
+  border-color: #000000;
+  background-color: #000000DD;
+}
+.about-page__credits__tooltip__note {
+  color: var(--theme__text-disabled-color);
+  font-style: italic;
+}
+.about-page__credits__tooltip__roles p {
+  background-color: #000000;
+}
+
+
+/* ------ Log ------ */
+/* Log-Page Bar */
+.log-page__bar {
+  background-color: #222222;
+}
+
+
+/* ------ Browse ------ */
+.game-browser {
+  background-color: var(--theme__background-color);
+}
+/* Sidebar */
+.game-browser__sidebar {
+  background-color: var(--theme__browse-sidebar__background-color);
+}
+.game-browser__sidebar__divider {
+  background-color: var(--theme__browse-sidebar__divider__background-color);
+}
+/* Browse-Right-Sidebar Additional-Application */
+.browse-right-sidebar__additional-application:nth-child(2n) {
+  background-color: #141417;
+}
+/* BrowseSidebar Title-Row Buttons */
+.browse-right-sidebar__title-row__buttons .icon__use {
+  fill: var(--layout__primary-text-color);
+}
+.browse-right-sidebar__title-row__buttons :hover .icon__use {
+  fill: #b1b1b1;
+}
+/* BrowseSidebar Title-Row Delete-Game */
+.browse-right-sidebar__title-row__buttons__delete-game:hover .icon__use {
+  fill: #aa4b4b;
+}
+.browse-right-sidebar__title-row__buttons__delete-game--active:hover .icon__use {
+  fill: #8a1212;
+}
+/* BrowseSidebar Title-Row Remove-From-Playlist */
+.browse-right-sidebar__title-row__buttons__remove-from-playlist:hover .icon__use {
+  fill: #aa4b4b;
+}
+.browse-right-sidebar__title-row__buttons__remove-from-playlist--active:hover .icon__use {
+  fill: #8a1212;
+}
+/* BrowseSidebar Title-Row Edit */
+.browse-right-sidebar__title-row__buttons__edit-button:hover .icon__use {
+  fill: #5cb468;
+}
+/* BrowseSidebar Title-Row Discard */
+.browse-right-sidebar__title-row__buttons__discard-button:hover .icon__use {
+  fill: #aa4b4b;
+}
+/* BrowseSidebar Title-Row Save */
+.browse-right-sidebar__title-row__buttons__save-button:hover .icon__use {
+  fill: #5cb468;
+}
+/* Browse-Right-Sidebar Row - Screenshot */
+.browse-right-sidebar__row__screenshot__placeholder {
+  background-color: #1b1b1b;
+  border-color: #818181;
+}
+.browse-right-sidebar__row__screenshot__placeholder p {
+  color: var(--theme__text-disabled-color);
+}
+/* GameImageSplit */
+.game-image-split {
+  --inner-border-color: #313131;
+}
+.game-image-split--hover {
+  background-color: #575757;
+}
+.game-image-split--disabled {
+  background-color: #141414;
+}
+.game-image-split:first-child {
+  border-right-color: var(--inner-border-color);
+}
+.game-image-split:last-child {
+  border-left-color: var(--inner-border-color);
+}
+.game-image-split__buttons__remove-image:hover .icon__use {
+  fill: #aa4b4b;
+}
+.game-image-split__buttons__remove-image--active:hover .icon__use {
+  fill: #8a1212;
+}
+
+
+/* GameList Item */
+.game-list-item {
+  list-style: none;
+  background-color: var(--theme__background-color);
+  color: var(--theme__game-item__color);
+}
+.game-list-item--even {
+  background-color: var(--theme__game-list-item__background-color-even);
+}
+.game-list-item:hover {
+  background-color: var(--theme__game-item__background-color-hover);
+  color: var(--theme__game-item__color-hover);
+}
+.game-list-item--selected {
+  background-color: var(--theme__game-item__background-color-selected);
+  color: var(--theme__game-item__color-selected);
+}
+.game-list-item--selected:hover {
+  background-color: var(--theme__game-item__background-color-selected-hover);
+  color: var(--theme__game-item__color-selected-hover);
+}
+/* GameList Item Thumb */
+.game-list-item__thumb {
+  image-rendering: var(--theme__game-item-thumb__image-rendering);
+}
+
+
+/* GameGrid */
+.game-grid-item {
+  color: var(--theme__game-item__color);
+}
+.game-grid-item:hover {
+  background-color: var(--theme__game-item__background-color-hover);
+  color: var(--theme__game-item__color-hover);
+}
+.game-grid-item--selected {
+  background-color: var(--theme__game-item__background-color-selected);
+  color: var(--theme__game-item__color-selected);
+}
+.game-grid-item--selected:hover {
+  background-color: var(--theme__game-item__background-color-selected-hover);
+  color: var(--theme__game-item__color-selected-hover);
+}
+.game-grid-item__thumb__image {
+  border-radius: 0.2em;
+  background-color: #242428;
+  border-color: #141417;
+  box-shadow: 0px 2px 4px 0px #09090a;
+  image-rendering: var(--theme__game-item-thumb__image-rendering);
+}
+
+/* Playlist-List-Item */
+.playlist-list-item {
+  background-color: var(--theme__background-color);
+  color: var(--color__aaa);
+}
+.playlist-list-item:nth-child(2n) {
+  background-color: var(--theme__playlist-list-item-even__background-color);
+}
+.playlist-list-item:hover,
+.playlist-list-item.playlist-list-item--drag-over {
+  background-color: #3c3c41;
+}
+.playlist-list-item--editing {
+  background-color: #151f14;
+}
+.playlist-list-item--editing:nth-child(2n) {
+  background-color: #192519;
+}
+.playlist-list-item--editing:hover,
+.playlist-list-item--editing.playlist-list-item--drag-over {
+  background-color: #20301f;
+}
+.playlist-list-item--drag-over .playlist-list-item__drag-overlay {
+  border-color: #818181;
+}
+/* Playlist-List-Item Head */
+.playlist-list-item__head {
+  --color: var(--color__aaa);
+  color: var(--color);
+}
+.playlist-list-item__head:hover,
+.playlist-list-item--drag-over .playlist-list-item__head {
+  --color: #e6e6e6;
+}
+.playlist-list-item__head__icon__no-image__icon .icon__use {
+  fill: var(--color);
+}
+/* Playlist-List-Item Content */
+.playlist-list-item__content {
+  background-color: #242425;
+}
+.playlist-list-item--editing .playlist-list-item__content {
+  background-color: #1c291b;
+  color: var(--color__playlist-description-while-edititng);
+}
+.playlist-list-item__content__description-edit {
+  background-color: #3a5637;
+}
+/* Playlist-List-Fake-Item */
+.playlist-list-fake-item {
+  background-color: var(--theme__playlist-list-fake-item__background-color);
+  --color: #aaaaaa;
+}
+.playlist-list-fake-item:hover {
+  background-color: #343438;
+  --color: #ffffff;
+}
+.playlist-list-fake-item__inner .icon__use {
+  fill: var(--color);
+}
+.playlist-list-fake-item__inner__title {
+  color: var(--color);
+}
+
+
+/** ------ Developer ------ */
+.developer-page__log {
+  background-color: #313133;
+  border-color: #353535;
+}
+
+
+/** ------ Config ------ */
+/* Setting */
+.setting__body {
+  background-color: #242428;
+  border-color: #141417;
+  box-shadow: 0px 2px 4px 0px #09090a;
+}
+/* Setting Row */
+.setting__row {
+  padding: 0.75em;
+}
+.setting__row:not(:first-child) {
+  border-top-color: #141417;
+}
+/* Setting Row Content - FilePoint Path */
+.setting__row__content--filepath-path .flashpoint-path__input {
+  border-color: var(--theme__search-bar__outline-color);
+}
+.setting__row__content--filepath-path .flashpoint-path__input--valid {
+  background-color: #009600;
+}
+.setting__row__content--filepath-path .flashpoint-path__input--invalid {
+  background-color: #840000;
+}
+.setting__row__content--filepath-path .flashpoint-path__input input[type="text"] {
+  color: var(--layout__primary-text-color);
+}
+/* Setting Row Content - Input Field */
+.setting__row__content--input-field > :first-child > * {
+  border-color: var(--theme__search-bar__outline-color);
+}
+/* Setting Row Content - Theme Input Field */
+.setting__row__content--theme-input-field label:last-child {
+  /* Change the color of the "No Theme" suggestion in the drop-down list. */
+  color: var(--color__no-theme-suggestion);
+}

--- a/static/window/styles/fancy.css
+++ b/static/window/styles/fancy.css
@@ -4,6 +4,7 @@
   --color__aaa: var(--layout__secondary-text-color);
   --color__playlist-description-while-edititng: #ffffff;
   --color__no-theme-suggestion: #bfbfbf;
+  --color__foot-slider-icon: #0f1010;
   /* Text */
   --layout__primary-text-color: #f1f1f1;
   --layout__secondary-text-color: #aaaaaa;
@@ -263,10 +264,10 @@ body {
 .footer__scale-slider__icon {
   font-family: monospace;
   font-weight: bold;
-  color: var(color__foot-slider-icon);
+  color: var(--color__foot-slider-icon);
 }
 .footer__scale-slider__icon--center {
-  background-color: var(color__foot-slider-icon);
+  background-color: var(--color__foot-slider-icon);
 }
 .footer__scale-slider__input {
   background: none;


### PR DESCRIPTION
- Split CSS from one file into two different files (``core.css`` and ``fancy.css``)
  * The first file (``core.css``) contains the styles that declare the size, position and such of elements
  * The second file (``fancy.css``) contains the styles that improves the visuals of the elements (mostly changing the colors)
- Move values that are likely to be changed by custom themes into css variables of ``:root``
- Refactor some styles to be easier to override from custom themes (this still needs work and testing)
