### PR TITLE
Clean up components

### DIFF
--- a/src/renderer/Util.ts
+++ b/src/renderer/Util.ts
@@ -109,3 +109,18 @@ export function findElementAncestor<T extends ElementBase<T>>(element: T, fn: El
   }
   return undefined;
 }
+
+/**
+ * Check if an element is the same as another element, or an ancestor of it.
+ * @param start First element to compare to (it will climb up the parents of this recursively).
+ * @param target Element to find.
+ * @returns If the "target" element was found.
+ */
+export function checkIfAncestor(start: Element | null, target: Element | null): boolean {
+  let element: Element | null = start;
+  while (element) {
+    if (element === target) { return true; }
+    element = element.parentElement;
+  }
+  return false;
+}

--- a/src/renderer/components/CheckBox.tsx
+++ b/src/renderer/components/CheckBox.tsx
@@ -1,27 +1,28 @@
 import * as React from 'react';
+import { useCallback } from 'react';
+import { Omit } from '../../shared/interfaces';
 
-export interface ICheckBoxProps {
-  className?: string;
-  style?: React.CSSProperties;
-  /** If this is checked (defaults to false if undefined) */
-  checked?: boolean;
-  /** Called when this becomes checked or unchecked */
-  onChange?: (isChecked: boolean) => void;
-}
+/** Props for an input element. */
+type InputProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
-export class CheckBox extends React.Component<ICheckBoxProps, {}> {
-  constructor(props: ICheckBoxProps) {
-    super(props);
-  }
+export type CheckBoxProps = Omit<InputProps, 'type'> & {
+  /** Called when the checkbox becomes checked or unchecked. This is called right after "onChange". */
+  onToggle?: (isChecked: boolean) => void;
+};
 
-  render() {
-    return (
-      <input type='checkbox' checked={this.props.checked} onChange={this.onChange}
-             className={this.props.className} style={this.props.style} />
-    );
-  }
-
-  onChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
-    if (this.props.onChange) { this.props.onChange(event.target.checked); }
-  }
+/** Basic checkbox element. Wrapper around the <input> element. */
+export function CheckBox(props: CheckBoxProps) {
+  const { onToggle, onChange, ...rest } = props;
+  // Hooks
+  const onChangeCallback = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    if (onChange) { onChange(event); }
+    if (onToggle) { onToggle(event.target.checked); }
+  }, [onToggle, onChange]);
+  // Render
+  return (
+    <input
+      { ...rest }
+      type='checkbox'
+      onChange={onChangeCallback} />
+  );
 }

--- a/src/renderer/components/ConfigFlashpointPathInput.tsx
+++ b/src/renderer/components/ConfigFlashpointPathInput.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
 
-export interface IConfigFlashpointPathInputProps {
-  /** Value of the input field */
+export type ConfigFlashpointPathInputProps = {
+  /** Initial value of the input field. */
   input?: string;
-  /** If the current input is valid */
+  /** If the current input is valid. */
   isValid?: boolean;
-  /** Called when the input is changed */
+  /** Called when the value of the input field is changed. */
   onInputChange?: (input: string) => void;
-}
+};
 
-export class ConfigFlashpointPathInput extends React.Component<IConfigFlashpointPathInputProps, {}> {
-  constructor(props: IConfigFlashpointPathInputProps) {
-    super(props);
-    if (props.onInputChange) { props.onInputChange(this.props.input || ''); }
+/** Text input element made specifically for setting the Flashpoint path at the config page. */
+export class ConfigFlashpointPathInput extends React.Component<ConfigFlashpointPathInputProps, {}> {
+  componentDidMount() {
+    if (this.props.onInputChange) { this.props.onInputChange(this.props.input || ''); }
   }
 
   render() {
-    const isValid = this.props.isValid;
+    const { input, isValid } = this.props;
     let className: string = 'flashpoint-path__input';
     if (isValid !== undefined) {
       className += isValid ? ' flashpoint-path__input--valid' : ' flashpoint-path__input--invalid';
@@ -24,9 +24,16 @@ export class ConfigFlashpointPathInput extends React.Component<IConfigFlashpoint
     return (
       <>
         <div className={className}>
-          <input type='text' onChange={this.onInputChange} value={this.props.input} />
+          <input
+            type='text'
+            onChange={this.onInputChange}
+            value={input} />
         </div>
-        <input type='button' value='Browse' className='simple-button' onClick={this.onBrowseClick} />
+        <input
+          type='button'
+          value='Browse'
+          className='simple-button'
+          onClick={this.onBrowseClick} />
       </>
     );
   }

--- a/src/renderer/components/ConfigFlashpointPathInput.tsx
+++ b/src/renderer/components/ConfigFlashpointPathInput.tsx
@@ -10,7 +10,7 @@ export type ConfigFlashpointPathInputProps = {
 };
 
 /** Text input element made specifically for setting the Flashpoint path at the config page. */
-export class ConfigFlashpointPathInput extends React.Component<ConfigFlashpointPathInputProps, {}> {
+export class ConfigFlashpointPathInput extends React.Component<ConfigFlashpointPathInputProps> {
   componentDidMount() {
     if (this.props.onInputChange) { this.props.onInputChange(this.props.input || ''); }
   }

--- a/src/renderer/components/ConfirmButton.tsx
+++ b/src/renderer/components/ConfirmButton.tsx
@@ -1,29 +1,31 @@
 import * as React from 'react';
 
-export interface ConfirmButtonPassthroughProps {
+/** Partial set of the props for <input>. */
+export type ConfirmButtonPassthroughProps = {
   value?: string;
   className?: string;
   title?: string;
   style?: React.CSSProperties;
-}
+};
 
-export interface ConfirmButtonProps {
-  /** Pass-through props that are always passed through */
+export type ConfirmButtonProps = {
+  /** Props that are always passed through to the input element. */
   props?: ConfirmButtonPassthroughProps;
-  /** Pass-through props that are passed while not confirming (overrides .props) */
+  /** Props that are passed through to the input element wile NOT confirming (this overrides "props"). */
   noConfirm?: ConfirmButtonPassthroughProps;
-  /** Pass-through props that are passed while confirming (overrides .props) */
+  /** Props that are passed through to the input element wile confirming (this overrides "props"). */
   confirm?: ConfirmButtonPassthroughProps;
-  /** If the button should skip the confirmation step and trigger onConfirm after the first click (false by default) */
+  /** If the button should skip the "confirmation step" and call "onConfirm" at the first click (false by default). */
   skipConfirm?: boolean;
-  /** Called when the button is clicked while confirming */
+  /** Called when the button is clicked twice without having the cursor leave the button (or just once if "skipConfirm" is true). */
   onConfirm?: () => void;
-}
+};
 
-export interface ConfirmButtonState {
+type ConfirmButtonState = {
   showConfirm: boolean;
-}
+};
 
+/** A button that requires two clicks to "activate", instead of one. */
 export class ConfirmButton extends React.Component<ConfirmButtonProps, ConfirmButtonState> {
   constructor(props: ConfirmButtonProps) {
     super(props);
@@ -33,21 +35,22 @@ export class ConfirmButton extends React.Component<ConfirmButtonProps, ConfirmBu
   }
 
   render() {
-    let props: ConfirmButtonPassthroughProps = Object.assign({}, this.props.props);
+    const props = Object.assign({}, this.props.props);
     if (this.state.showConfirm) {
       Object.assign(props, this.props.confirm);
     } else {
       Object.assign(props, this.props.noConfirm);
     }
     return (
-      <input type='button'
-             onClick={this.onClick} 
-             onMouseLeave={this.onMouseLeave} 
-             {...props} />
+      <input
+        type='button'
+        onClick={this.onClick} 
+        onMouseLeave={this.onMouseLeave} 
+        { ...props } />
     );
   }
 
-  private onClick = (): void => {
+  onClick = (): void => {
     if (this.props.skipConfirm) {
       if (this.props.onConfirm) { this.props.onConfirm(); }
     } else {
@@ -60,7 +63,7 @@ export class ConfirmButton extends React.Component<ConfirmButtonProps, ConfirmBu
     }
   }
 
-  private onMouseLeave = (): void => {
+  onMouseLeave = (): void => {
     if (this.state.showConfirm) {
       this.setState({ showConfirm: false });
     }

--- a/src/renderer/components/ConfirmElement.tsx
+++ b/src/renderer/components/ConfirmElement.tsx
@@ -1,64 +1,35 @@
 import * as React from 'react';
+import { useConfirm } from '../hooks/useConfirm';
 
-export interface IConfirmElementArgs {
+export type ConfirmElementArgs = {
   /** Number of times this has been activated since the last reset. */
   activationCounter: number;
-  /** Increments "activationCounter" then fires "onConfirm" if the counter exceeds "activationLimit". */
+  /** Increments "activationCounter" (and then calls "onConfirm" if the counter exceeds "activationLimit"). */
   activate: () => void;
   /** Calls the "onConfirm" callback (does not change or reset "activationCounter") */
   confirm: () => void;
   /** Resets "activationCounter". */
   reset: () => void;
-}
+};
 
-export interface IConfirmElementProps {
-  children?: (args: IConfirmElementArgs) => JSX.Element|void;
+export type ConfirmElementProps = {
+  /** Function that renders the element (render prop). */
+  children?: (args: ConfirmElementArgs) => JSX.Element | void;
+  /** Number of activations needed to confirm. */
   activationLimit?: number;
+  /** Called when confirmed. */
   onConfirm?: () => void;
-}
+};
 
-export interface IConfirmButtonState {
-  activationCounter: number;
-}
-
-export class ConfirmElement extends React.Component<IConfirmElementProps, IConfirmButtonState> {
-  constructor(props: IConfirmElementProps) {
-    super(props);
-    this.state = {
-      activationCounter: 0,
-    };
-  }
-
-  render() {
-    if (!this.props.children) { return (<></>); }
-    return this.props.children({
-      activationCounter: this.state.activationCounter,
-      activate: this.activate,
-      reset: this.reset,
-      confirm: this.confirm,
-    }) || (<></>);
-  }
-
-  private activate = (): void => {
-    let limit = (this.props.activationLimit !== undefined) ? this.props.activationLimit : 1;
-    let nextCount = this.state.activationCounter + 1;
-    if (nextCount > limit) {
-      this.confirm();
-      this.reset();
-    } else {
-      this.setState({ activationCounter: nextCount });
-    }
-  }
-
-  private confirm = (): void => {
-    if (this.props.onConfirm) {
-      this.props.onConfirm();
-    }
-  }
-
-  private reset = (): void => {
-    if (this.state.activationCounter !== 0) {
-      this.setState({ activationCounter: 0 });
-    }
-  }
+/** Wrapper component around the "useConfirm" hook. */
+export function ConfirmElement(props: ConfirmElementProps) {
+  // Hooks
+  const [count, activate, confirm, reset] = useConfirm(props.activationLimit, props.onConfirm);
+  // Render
+  return props.children && props.children({
+    activationCounter: count,
+    activate: activate,
+    reset: reset,
+    confirm: confirm,
+  }) || (<></>);
 }

--- a/src/renderer/components/CreditsProfile.tsx
+++ b/src/renderer/components/CreditsProfile.tsx
@@ -1,48 +1,44 @@
 import * as React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { ICreditsDataProfile } from '../credits/interfaces';
 
-export interface ICreditsIconProps {
+export type CreditsIconProps = {
+  /** Credits profile of the person to display. */
   profile: ICreditsDataProfile;
+  /** Called when the mouse enters the element. */
   onMouseEnter: (profile: ICreditsDataProfile) => void;
+  /** Called when the mouse leaves the element. */
   onMouseLeave: () => void;
-}
+};
 
-export class CreditsIcon extends React.PureComponent<ICreditsIconProps> {
-  private timeout: number = -1;
-  private ref: React.RefObject<HTMLDivElement> = React.createRef();
-
-  componentDidMount() {
-    this.timeout = window.setTimeout(() => {
-      this.timeout = -1;
-      if (!this.ref.current) { throw new Error('CreditsIcon could not set profile image. Image element is missing.'); }
-      if (this.props.profile.icon) {
-        this.ref.current.style.backgroundImage = `url("${this.props.profile.icon}")`;
+/** Displays an icon from a credits profile. */
+export function CreditsIcon(props: CreditsIconProps) {
+  // Hooks
+  const ref = useRef<HTMLDivElement>(null);
+  const onMouseEnter = useCallback(() => {
+    if (props.onMouseEnter) { props.onMouseEnter(props.profile); }
+  }, [props.onMouseEnter, props.profile]);
+  const onMouseLeave = useCallback(() => {
+    if (props.onMouseLeave) { props.onMouseLeave(); }
+  }, [props.onMouseLeave]);
+  useEffect(() => { // (Delay decoding the icon, this allows the browser to spread the work across multiple frames)
+    let timeout = window.setTimeout(() => {
+      timeout = -1;
+      if (!ref.current) { throw new Error('CreditsIcon could not set profile image. Image element is missing.'); }
+      if (props.profile.icon) {
+        ref.current.style.backgroundImage = `url("${props.profile.icon}")`;
       }
     }, 0);
-  }
-
-  componentWillUnmount() {
-    if (this.timeout >= 0) {
-      window.clearTimeout(this.timeout);
-    }
-  }
-
-  render() {
-    const { profile } = this.props;
-    return (
-      <div className='about-page__credits__profile'
-           ref={this.ref}
-           onMouseEnter={this.onMouseEnter}
-           onMouseLeave={this.onMouseLeave}>
-      </div>
-    );
-  }
-
-  private onMouseEnter = (event: React.MouseEvent) => {
-    if (this.props.onMouseEnter) { this.props.onMouseEnter(this.props.profile); }
-  }
-
-  private onMouseLeave = (event: React.MouseEvent) => {
-    if (this.props.onMouseLeave) { this.props.onMouseLeave(); }
-  }
+    return () => {
+      if (timeout >= 0) { window.clearTimeout(timeout); }
+    };
+  }, [props.profile]);
+  // Render
+  return (
+    <div
+      className='about-page__credits__profile'
+      ref={ref}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave} />
+  );
 }

--- a/src/renderer/components/CreditsTooltip.tsx
+++ b/src/renderer/components/CreditsTooltip.tsx
@@ -1,50 +1,55 @@
 import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import { ICreditsDataProfile } from '../credits/interfaces';
 
-export interface ICreditsTooltipProps {
+export type CreditsTooltipProps = {
+  /** Credits profile to show in the tooltip. If undefined, the tooltip will be hidden. */
   profile?: ICreditsDataProfile;
+};
+
+/** Tooltip that follows the cursor and displays information about a credits profile. */
+export function CreditsTooltip(props: CreditsTooltipProps) {
+  // Hooks
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current && props.profile) { // (Check if the tooltip is visible)
+      const onMouseMove = createOnMouseMove(ref.current);
+      window.addEventListener('mousemove', onMouseMove);
+      return () => { window.removeEventListener('mousemove', onMouseMove); };
+    }
+  }, [ref.current, props.profile]);
+  // Render
+  return (
+    <div
+      className='about-page__credits__tooltip'
+      ref={ref}
+      style={{ display: props.profile ? undefined : 'none' }}>
+      { props.profile ? (
+        <>
+          <p className='about-page__credits__tooltip__title'>{props.profile.title}</p>
+          { props.profile.note ? (
+            <p className='about-page__credits__tooltip__note'>{props.profile.note}</p>
+          ) : undefined }
+            <ul className='about-page__credits__tooltip__roles'>
+              { props.profile.roles.map((role, index) => (
+                <li key={index} style={{ color: getRoleColor(role) }}>
+                  <p>{role}</p>
+                </li>
+              )) }
+            </ul>
+        </>
+      ) : undefined }
+    </div>
+  );
 }
 
-export class CreditsTooltip extends React.PureComponent<ICreditsTooltipProps> {
-  private ref: React.RefObject<HTMLDivElement> = React.createRef();
-
-
-  componentDidMount() {
-    window.addEventListener('mousemove', this.onMouseMove);
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('mousemove', this.onMouseMove);
-  }
-
-  render() {
-    const { profile } = this.props;
-    return (
-      <div className='about-page__credits__tooltip'
-           ref={this.ref}
-           style={{ display: profile ? undefined : 'none' }}>
-        { profile ? (
-          <>
-            <p className='about-page__credits__tooltip__title'>{profile.title}</p>
-            { profile.note ? (
-              <p className='about-page__credits__tooltip__note'>{profile.note}</p>
-            ) : undefined }
-              <ul className='about-page__credits__tooltip__roles'>
-                { profile.roles.map((role, index) => (
-                  <li key={index} style={{ color: CreditsTooltip.getRoleColor(role) }}>
-                    <p>{role}</p>
-                  </li>
-                )) }
-              </ul>
-          </>
-        ) : undefined }
-      </div>
-    );
-  }
-
-  private onMouseMove = (event: MouseEvent) => {
-    const current = this.ref.current;
-    if (current && this.props.profile) {
+/**
+ * Create an "on mouse move" event listener for the tooltip.
+ * @param current Base tooltip element to move around.
+ */
+function createOnMouseMove(current: HTMLElement): (event: MouseEvent) => void {
+  return (event) => {
+    if (current) {
       if (event.clientX <= window.innerWidth * 0.5) {
         current.style.left  = (event.clientX + 16)+'px';
         current.style.right = null;
@@ -55,20 +60,26 @@ export class CreditsTooltip extends React.PureComponent<ICreditsTooltipProps> {
       current.style.top  = (event.clientY +  8)+'px';
     }
   }
+}
 
-  private static getRoleColor(role: string): string | undefined {
-    switch (role) {
-      default:              return undefined;
-      case 'Mechanic':      return 'rgb(84, 110, 122)';
-      case 'Moderator':     return 'rgb(46, 204, 113)';
-      case 'Curator':       return 'rgb(241, 196, 15)';
-      case 'The Blue':      return 'rgb(32, 102, 148)';
-      case 'The Moe':       return 'rgb(224, 164, 241)';
-      case 'Administrator': return 'rgb(52, 152, 219)';
-      case 'Hacker':        return 'rgb(177, 21, 21)';
-      case 'Archivist':     return 'rgb(170, 135, 135)';
-      case 'Tester':        return 'rgb(230, 126, 34)';
-      case 'VIP':           return 'rgb(214, 4, 127)';
-    }
+/**
+ * Get the color associated with a specific role.
+ * @param role Role to get the associated color for.
+ */
+function getRoleColor(role: string): string | undefined {
+  // @TODO Rewrite this function to return css class names, and define the colors the a stylesheet instead.
+  //       That way you can change the colors with a theme.
+  switch (role) {
+    default:              return undefined;
+    case 'Mechanic':      return 'rgb(84, 110, 122)';
+    case 'Moderator':     return 'rgb(46, 204, 113)';
+    case 'Curator':       return 'rgb(241, 196, 15)';
+    case 'The Blue':      return 'rgb(32, 102, 148)';
+    case 'The Moe':       return 'rgb(224, 164, 241)';
+    case 'Administrator': return 'rgb(52, 152, 219)';
+    case 'Hacker':        return 'rgb(177, 21, 21)';
+    case 'Archivist':     return 'rgb(170, 135, 135)';
+    case 'Tester':        return 'rgb(230, 126, 34)';
+    case 'VIP':           return 'rgb(214, 4, 127)';
   }
 }

--- a/src/renderer/components/EditableTextElement.tsx
+++ b/src/renderer/components/EditableTextElement.tsx
@@ -1,45 +1,59 @@
 import * as React from 'react';
 
-export interface IEditableTextElementArgs {
+export type EditableTextElementArgs = {
+  /** If this is in "edit mode" (instead of "view mode"). */
   editing: boolean;
+  /** Current text. */
   text: string;
+  /** Enter "edit mode". */
   startEdit: () => void;
+  /** Leave "edit mode" and discard the edited text. */
   cancelEdit: () => void;
+  /** Leave "edit mode" and "lock in" the edited text. */
   confirmEdit: () => void;
+  /** Call this whenever the input is changed (while in "edit mode"). */
   onInputChange: (event: React.ChangeEvent<{ value: string }>) => void;
+  /** Call this whenever a key is pressed (while in "edit mode" and the text element is receiving the input). */
   onInputKeyDown: (event: React.KeyboardEvent) => void;
-}
+};
 
-export interface IEditableTextElementKeyArgs {
+export type EditableTextElementKeyArgs = {
+  /** Keyboard event. */
   event: React.KeyboardEvent;
-  /** Cancel edit */
+  /** Cancel edit (discard changes). */
   cancel: () => void;
-  /** Confirm edit */
+  /** Confirm edit ("lock in" changes). */
   confirm: () => void;
-}
+};
 
-export interface IEditableTextElementProps {
-  /** Function that renders the editable text */
-  children?: (args: IEditableTextElementArgs) => JSX.Element|void;
-  /** Called when editing is confirmed */
+export type EditableTextElementProps = {
+  /** Function that renders the text element (render prop). */
+  children?: (args: EditableTextElementArgs) => JSX.Element|void;
+  /** Called when editing is confirmed (when the user is done editing and attempts to "lock in" the edited text). */
   onEditConfirm?: (text: string) => void;
-  /** Called when editing is cancelled */
+  /** Called when editing is cancelled (when the user is done editing and attempts to discard the edited text). */
   onEditCancel?: (text: string) => void;
-  /** Called when a key is pushed down while editing */
-  onEditKeyDown?: (args: IEditableTextElementKeyArgs) => void;
-  /** If the element is editable (if it can go to the "edit mode") */
+  /** Called when a key is pushed down while editing (called from the render prop argument "onInputKeyDown"). */
+  onEditKeyDown?: (args: EditableTextElementKeyArgs) => void;
+  /** If the element is editable (if it can enter "edit mode"). */
   editable?: boolean;
-  /** Text to be displayed (and to edit when it goes into "edit mode") */
+  /** Text to be displayed (and to edit when it enters "edit mode"). */
   text: string;
-}
+};
 
-export interface IEditableTextElementState {
+type EditableTextElementState = {
+  /** If this is in "edit mode" (instead of "view mode"). */
   editing: boolean;
+  /** Current text. */
   text: string;
-}
+};
 
-export class EditableTextElement extends React.Component<IEditableTextElementProps, IEditableTextElementState> {
-  constructor(props: IEditableTextElementProps) {
+/**
+ * A "render prop" component that stores and manages state for an editable text field.
+ * Note that this is an old component that should probably be replaced with something nicer.
+ */
+export class EditableTextElement extends React.Component<EditableTextElementProps, EditableTextElementState> {
+  constructor(props: EditableTextElementProps) {
     super(props);
     this.state = {
       editing: false,
@@ -71,37 +85,38 @@ export class EditableTextElement extends React.Component<IEditableTextElementPro
     }
   }
 
-  private startEdit = (): void => {
+  startEdit = (): void => {
     if (this.props.editable) {
       this.setState({ editing: true });
     }
   }
 
-  private cancelEdit = (): void => {
+  cancelEdit = (): void => {
     this.setState({ editing: false });
     this.props.onEditCancel && this.props.onEditCancel(this.state.text);
   }
 
-  private confirmEdit = (): void => {
+  confirmEdit = (): void => {
     this.setState({ editing: false });
     this.props.onEditConfirm && this.props.onEditConfirm(this.state.text);
   }
 
-  private onInputChange = (event: React.ChangeEvent<{ value: string }>): void => {
+  onInputChange = (event: React.ChangeEvent<{ value: string }>): void => {
     this.setState({ text: event.target.value });
   }
 
-  private onInputKeyDown = (event: React.KeyboardEvent): void => {
-    if (!this.state.editing) { return; }
-    const func = this.props.onEditKeyDown || EditableTextElement.onEditKeyDown;
-    func({
-      event,
-      cancel: this.cancelEdit,
-      confirm: this.confirmEdit,
-    });
+  onInputKeyDown = (event: React.KeyboardEvent): void => {
+    if (this.state.editing) {
+      const func = this.props.onEditKeyDown || EditableTextElement.onEditKeyDown;
+      func({
+        event,
+        cancel: this.cancelEdit,
+        confirm: this.confirmEdit,
+      });
+    }
   }
 
-  public static onEditKeyDown({ event, cancel, confirm }: IEditableTextElementKeyArgs): void {
+  public static onEditKeyDown({ event, cancel, confirm }: EditableTextElementKeyArgs): void {
     if (event.key === 'Enter' && !event.shiftKey) {
       confirm();
     } else if (event.key === 'Escape') {

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -1,36 +1,36 @@
 import * as React from 'react';
 import { BrowsePageLayout, parseBrowsePageLayout, stringifyBrowsePageLayout } from '../../shared/BrowsePageLayout';
 import { WithPreferencesProps } from '../containers/withPreferences';
-import { IDefaultProps } from '../interfaces';
 import { gameScaleSpan } from '../Util';
 
-interface OwnProps extends IDefaultProps {
+type OwnProps = {
+  /** If the "total" and "current label" counts should be shown. */
   showCount: boolean;
+  /** Total number of games. */
   totalCount?: number;
+  /** Label of the current browse library (if any). */
   currentLabel?: string;
+  /** Number of games in the current browse library (if there is a current browse library). */
   currentCount?: number;
-  /** Value of the scale slider (between 0 - 1) */
+  /** Value of the scale slider (between 0 and 1). */
   scaleSliderValue: number;
-  /** When the value of the scale slider is changed (value is between 0 and 1) */
+  /** Called when the value of the scale slider is changed (value is between 0 and 1). */
   onScaleSliderChange?: (value: number) => void;
-  /** BrowsePage layout */
+  /** Current BrowsePage layout. */
   layout: BrowsePageLayout;
-  /** When the value of the layout selector is changed */
+  /** Called when the value of the layout selector is changed. */
   onLayoutChange?: (value: BrowsePageLayout) => void;
-  /** When the "New Game" button is clicked */
+  /** Called when the "New Game" button is clicked. */
   onNewGameClick?: () => void;
-}
+};
 
-export type IFooterProps = OwnProps & IDefaultProps & WithPreferencesProps;
+export type FooterProps = OwnProps & WithPreferencesProps;
 
-export class Footer extends React.Component<IFooterProps, {}> {
-  private static scaleSliderMax: number = 1000;
+/** The footer that is always visible at the bottom of the main window. */
+export class Footer extends React.Component<FooterProps, {}> {
+  static scaleSliderMax: number = 1000;
   /** Reference to the scale slider. */
-  private _scaleSliderRef: React.RefObject<HTMLInputElement> = React.createRef();
-
-  constructor(props: IFooterProps) {
-    super(props);
-  }
+  scaleSliderRef: React.RefObject<HTMLInputElement> = React.createRef();
 
   componentDidMount() {
     window.addEventListener('keydown', this.onGlobalKeydown);
@@ -69,15 +69,21 @@ export class Footer extends React.Component<IFooterProps, {}> {
               { preferencesData.enableEditing ? (
                 <div className='footer__wrap'>
                   <div className='simple-center'>
-                    <input type='button' value='New Game' onClick={onNewGameClick}
-                          className='footer__new-game simple-button simple-center__vertical-inner' />
+                    <input
+                      type='button'
+                      value='New Game'
+                      onClick={onNewGameClick}
+                      className='footer__new-game simple-button simple-center__vertical-inner' />
                   </div>
                 </div>
               ) : undefined }
               {/* Layout Selector */}
               <div className='footer__wrap'>
                 <div>
-                  <select className='footer__layout-selector simple-selector' value={stringifyBrowsePageLayout(layout)} onChange={this.onLayoutChange}>
+                  <select
+                    className='footer__layout-selector simple-selector'
+                    value={stringifyBrowsePageLayout(layout)}
+                    onChange={this.onLayoutChange}>
                     <option value='list'>List</option>
                     <option value='grid'>Grid</option>
                   </select>
@@ -93,9 +99,14 @@ export class Footer extends React.Component<IFooterProps, {}> {
                   <div className='footer__scale-slider__icon footer__scale-slider__icon--right simple-center'>
                     <div>+</div>
                   </div>
-                  <input type='range' className='footer__scale-slider__input hidden-slider'
-                         value={scale * Footer.scaleSliderMax} min={0} max={Footer.scaleSliderMax}
-                         ref={this._scaleSliderRef} onChange={this.onScaleSliderChange} />
+                  <input
+                    type='range'
+                    className='footer__scale-slider__input hidden-slider'
+                    value={scale * Footer.scaleSliderMax}
+                    min={0}
+                    max={Footer.scaleSliderMax}
+                    ref={this.scaleSliderRef}
+                    onChange={this.onScaleSliderChange} />
                 </div>
               </div>
               {/* Slider Percent */}
@@ -152,10 +163,10 @@ export class Footer extends React.Component<IFooterProps, {}> {
    * @param scale Value (between 0 and 1).
    */
   setScaleSliderValue(scale: number): void {
-    if (this._scaleSliderRef.current) {
+    if (this.scaleSliderRef.current) {
       const value = Math.min(Math.max(0, scale), 1) * Footer.scaleSliderMax;
-      this._scaleSliderRef.current.value = value+'';
-      this.scaleSliderChange(this._scaleSliderRef.current);
+      this.scaleSliderRef.current.value = value+'';
+      this.scaleSliderChange(this.scaleSliderRef.current);
     }
   }
 }

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -27,7 +27,7 @@ type OwnProps = {
 export type FooterProps = OwnProps & WithPreferencesProps;
 
 /** The footer that is always visible at the bottom of the main window. */
-export class Footer extends React.Component<FooterProps, {}> {
+export class Footer extends React.Component<FooterProps> {
   static scaleSliderMax: number = 1000;
   /** Reference to the scale slider. */
   scaleSliderRef: React.RefObject<HTMLInputElement> = React.createRef();

--- a/src/renderer/components/GameGrid.tsx
+++ b/src/renderer/components/GameGrid.tsx
@@ -43,7 +43,7 @@ export type GameGridProps = {
 };
 
 /** A grid of cells, where each cell displays a game. */
-export class GameGrid extends React.Component<GameGridProps, {}> {
+export class GameGrid extends React.Component<GameGridProps> {
   wrapperRef: React.RefObject<HTMLDivElement> = React.createRef();
   /** Number of columns in the grid from the most recent render. */
   columns: number = 0;

--- a/src/renderer/components/GameGridItem.tsx
+++ b/src/renderer/components/GameGridItem.tsx
@@ -1,27 +1,23 @@
 import * as React from 'react';
 import { GridCellProps } from 'react-virtualized';
 import { IGameInfo } from '../../shared/game/interfaces';
-import { IDefaultProps } from '../interfaces';
 import { getPlatformIconPath } from '../Util';
 
-export interface IGameGridItemProps extends Partial<GridCellProps>, IDefaultProps {
-  /** Game to show */
+export type GameGridItemProps = Partial<GridCellProps> & {
+  /** Game to display. */
   game: IGameInfo;
-  /** Path to the games thumbnail */
+  /** Path to the game's thumbnail. */
   thumbnail: string;
-  /** If the grid item can be dragged (defaults to false) */
+  /** If the cell can be dragged (defaults to false). */
   isDraggable?: boolean;
-  /** If the grid item is selected */
+  /** If the cell is selected. */
   isSelected: boolean;
-  /** If the grid item is being dragged */
+  /** If the cell is being dragged. */
   isDragged: boolean;
-}
+};
 
-export class GameGridItem extends React.Component<IGameGridItemProps, {}> {
-  constructor(props: IGameGridItemProps) {
-    super(props);
-  }
-
+/** Displays a single game. Meant to be rendered inside a grid. */
+export class GameGridItem extends React.Component<GameGridItemProps, {}> {
   render() {
     const game = this.props.game;
     const platformIcon = getPlatformIconPath(game.platform);
@@ -34,19 +30,20 @@ export class GameGridItem extends React.Component<IGameGridItemProps, {}> {
     if (this.props.isDragged)  { className += ' game-grid-item--dragged';  }
     // Render
     return (
-      <li style={this.props.style}
-          className={className}
-          draggable={this.props.isDraggable}
-          { ...attributes }>
+      <li
+        style={this.props.style}
+        className={className}
+        draggable={this.props.isDraggable}
+        { ...attributes }>
         <div className='game-grid-item__thumb'>
-          <div className='game-grid-item__thumb__image' style={{
-            backgroundImage: `url('${this.props.thumbnail}')`
-          }}>
+          <div
+            className='game-grid-item__thumb__image'
+            style={{ backgroundImage: `url('${this.props.thumbnail}')` }}>
             <div className='game-grid-item__thumb__icons'>
               {(platformIcon) ? (
-                <div className='game-grid-item__thumb__icons__icon' style={{
-                  backgroundImage: `url('${platformIcon}')`
-                }} />
+                <div
+                  className='game-grid-item__thumb__icons__icon'
+                  style={{ backgroundImage: `url('${platformIcon}')` }} />
               ) : undefined }
             </div>
           </div>

--- a/src/renderer/components/GameGridItem.tsx
+++ b/src/renderer/components/GameGridItem.tsx
@@ -17,7 +17,7 @@ export type GameGridItemProps = Partial<GridCellProps> & {
 };
 
 /** Displays a single game. Meant to be rendered inside a grid. */
-export class GameGridItem extends React.Component<GameGridItemProps, {}> {
+export class GameGridItem extends React.Component<GameGridItemProps> {
   render() {
     const game = this.props.game;
     const platformIcon = getPlatformIconPath(game.platform);

--- a/src/renderer/components/GameImageSplit.tsx
+++ b/src/renderer/components/GameImageSplit.tsx
@@ -1,81 +1,96 @@
 import * as React from 'react';
-import { ConfirmElement, IConfirmElementArgs } from './ConfirmElement';
+import { ConfirmElement, ConfirmElementArgs } from './ConfirmElement';
 import { OpenIcon } from './OpenIcon';
 import { SimpleButton } from './SimpleButton';
 
-interface IGameImageSplitProps {
+type GameImageSplitProps = {
   text: string;
   imgSrc?: string;
   onAddClick: () => void;
   onRemoveClick: () => void;
   onDrop: (event: React.DragEvent, text: string) => void;
   disabled?: boolean;
-}
+};
 
-interface IGameImageSplitState {
+type GameImageSplitState = {
   hover: boolean;
 };
 
-export class GameImageSplit extends React.Component<IGameImageSplitProps, IGameImageSplitState> {
-  constructor(props: IGameImageSplitProps) {
+export class GameImageSplit extends React.Component<GameImageSplitProps, GameImageSplitState> {
+  constructor(props: GameImageSplitProps) {
     super(props);
-    this.state = { hover: false };
+    this.state = {
+      hover: false,
+    };
   }
 
   render() {
     const { disabled, imgSrc, onAddClick, onRemoveClick, text } = this.props;
     const { hover } = this.state;
+    // Class name
+    let className = 'game-image-split';
+    if (imgSrc === undefined) { className += ' simple-center'; }
+    if (hover)                { className += ' game-image-split--hover'; }
+    if (disabled)             { className += ' game-image-split--disabled'; }
+    // Render
     return (
-      <div className={'game-image-split' +
-                      ((imgSrc === undefined) ? ' simple-center' : '') +
-                      (hover ? ' game-image-split--hover' : '') +
-                      (disabled ? ' game-image-split--disabled' : '')}
-          style={{ backgroundImage: `url("${imgSrc}")` }}
-          onDragOver={this.onDragOver}
-          onDragLeave={this.onDragLeave}
-          onDrop={this.onDrop}>
+      <div
+        className={className}
+        style={{ backgroundImage: `url("${imgSrc}")` }}
+        onDragOver={this.onDragOver}
+        onDragLeave={this.onDragLeave}
+        onDrop={this.onDrop}>
         { (imgSrc === undefined) ? (
           <div className='game-image-split__not-found'>
-            <h1>{`No ${text} Found`}</h1>
-            <SimpleButton value={`Add ${text}`} onClick={onAddClick} disabled={disabled}/>
+            <h1>No {text} Found</h1>
+            <SimpleButton
+              value={`Add ${text}`}
+              onClick={onAddClick}
+              disabled={disabled}/>
           </div>
         ) : (
           <div className='game-image-split__buttons'>
             <p>{text}</p>
-            <ConfirmElement onConfirm={onRemoveClick} children={renderDeleteImageButton}/>
+            <ConfirmElement
+              onConfirm={onRemoveClick}
+              children={renderDeleteImageButton}/>
           </div>
         ) }
       </div>
     );
   }
 
-  private onDragOver = (event: React.DragEvent): void => {
-    if (this.props.imgSrc !== undefined) { return; }
-    const types = event.dataTransfer.types;
-    if (types.length === 1 && types[0] === 'Files') {
-      event.preventDefault();
-      event.dataTransfer.dropEffect = 'copy';
-      if (!this.state.hover) { this.setState({ hover: true }); }
+  onDragOver = (event: React.DragEvent): void => {
+    if (this.props.imgSrc === undefined) {
+      const types = event.dataTransfer.types;
+      if (types.length === 1 && types[0] === 'Files') {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'copy';
+        if (!this.state.hover) { this.setState({ hover: true }); }
+      }      
     }
   }
 
-  private onDrop = (event: React.DragEvent): void => {
+  onDrop = (event: React.DragEvent): void => {
     if (this.state.hover) { this.setState({ hover: false }); }
-    if (this.props.imgSrc !== undefined) { return; }
-    this.props.onDrop(event, this.props.text);
+    if (this.props.imgSrc === undefined) { this.props.onDrop(event, this.props.text); }
   }
 
-  private onDragLeave = (event: React.DragEvent): void => {
+  onDragLeave = (event: React.DragEvent): void => {
     if (this.state.hover) { this.setState({ hover: false }); }
   }
 }
 
-function renderDeleteImageButton({ activate, activationCounter, reset }: IConfirmElementArgs): JSX.Element {
+function renderDeleteImageButton({ activate, activationCounter, reset }: ConfirmElementArgs): JSX.Element {
   return (
-    <div className={'game-image-split__buttons__remove-image'+
-                    ((activationCounter>0)?' game-image-split__buttons__remove-image--active simple-vertical-shake':'')}
-         title='Delete Image (delete ALL images of this game of the same type)'
-         onClick={activate} onMouseLeave={reset}>
+    <div
+      className={
+        'game-image-split__buttons__remove-image' +
+        ((activationCounter > 0) ? ' game-image-split__buttons__remove-image--active simple-vertical-shake' : '')
+      }
+      title='Delete Image (delete ALL images of this game of the same type)'
+      onClick={activate}
+      onMouseLeave={reset}>
       <OpenIcon icon='trash' />
     </div>
   );

--- a/src/renderer/components/GameImageSplit.tsx
+++ b/src/renderer/components/GameImageSplit.tsx
@@ -4,18 +4,30 @@ import { OpenIcon } from './OpenIcon';
 import { SimpleButton } from './SimpleButton';
 
 type GameImageSplitProps = {
+  /** What to call the image (perhaps the type or purpose of the image). */
   text: string;
+  /** Source of the image (undefined if there is no image). */
   imgSrc?: string;
+  /** Called when the "add" button is clicked. This button is only shown while there is no image. */
   onAddClick: () => void;
+  /** Called when the "remove" button is clicked. This button is only shown while there is an image. */
   onRemoveClick: () => void;
+  /** Called when something is dropped on this component. */
   onDrop: (event: React.DragEvent, text: string) => void;
+  /** If the user should not be able to add a new image. */
   disabled?: boolean;
 };
 
 type GameImageSplitState = {
+  /** If the cursor is dragging something over this element. */
   hover: boolean;
 };
 
+/**
+ * An "image slot" inside the "game image split" area.
+ * This component will either display a text and an "add" button, or an image and a "remove" button (depending on if the image source is undefined).
+ * It's meant to be used for displaying the current, or allowing the user to add a new, image for a game.
+ */
 export class GameImageSplit extends React.Component<GameImageSplitProps, GameImageSplitState> {
   constructor(props: GameImageSplitProps) {
     super(props);

--- a/src/renderer/components/GameItemContainer.tsx
+++ b/src/renderer/components/GameItemContainer.tsx
@@ -20,35 +20,32 @@ export type GameItemContainerProps = HTMLDivProps & {
 };
 
 /**
- * A DIV element with additional props that listenes for "game item" events that bubbles up.
+ * A DIV element with additional props that listens for "game item" events that bubbles up.
  * This is more efficient than listening for events on each "game item" individually.
  */
 export class GameItemContainer extends React.Component<GameItemContainerProps> {
-  constructor(props: GameItemContainerProps) {
-    super(props);
-  }
-  
   render() {
     return (
-      <div { ...filterDivProps(this.props) }
-           ref={this.props.realRef}
-           onClick={this.onClick}
-           onDoubleClick={this.onDoubleClick}
-           onContextMenu={this.onContextMenu}
-           onDragStart={this.onDragStart}
-           onDragEnd={this.onDragEnd}
-           children={this.props.children} />
+      <div
+        { ...filterDivProps(this.props) }
+        ref={this.props.realRef}
+        onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
+        onContextMenu={this.onContextMenu}
+        onDragStart={this.onDragStart}
+        onDragEnd={this.onDragEnd}
+        children={this.props.children} />
     );
   }
 
-  private onClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  onClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (this.props.onClick) { this.props.onClick(event); }
     if (this.props.onGameSelect) {
       this.props.onGameSelect(event, this.findGameId(event.target));
     }
   }
 
-  private onDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  onDoubleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (this.props.onDoubleClick) { this.props.onDoubleClick(event); }
     if (this.props.onGameLaunch) {
       const gameId = this.findGameId(event.target);
@@ -56,7 +53,7 @@ export class GameItemContainer extends React.Component<GameItemContainerProps> {
     }
   }
 
-  private onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+  onContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     if (this.props.onContextMenu) { this.props.onContextMenu(event); }
     if (this.props.onGameContextMenu) {
       const gameId = this.findGameId(event.target);
@@ -64,7 +61,7 @@ export class GameItemContainer extends React.Component<GameItemContainerProps> {
     }
   }
 
-  private onDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+  onDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     if (this.props.onDragStart) { this.props.onDragStart(event); }
     if (this.props.onGameDragStart) {
       const gameId = this.findGameId(event.target);
@@ -72,7 +69,7 @@ export class GameItemContainer extends React.Component<GameItemContainerProps> {
     }
   }
 
-  private onDragEnd = (event: React.DragEvent<HTMLDivElement>) => {
+  onDragEnd = (event: React.DragEvent<HTMLDivElement>) => {
     if (this.props.onDragEnd) { this.props.onDragEnd(event); }
     if (this.props.onGameDragEnd) {
       const gameId = this.findGameId(event.target);
@@ -81,7 +78,7 @@ export class GameItemContainer extends React.Component<GameItemContainerProps> {
   }
 
   /** Short-hand for "props.findGameId". */
-  private findGameId(target: EventTarget): string | undefined {
+  findGameId(target: EventTarget): string | undefined {
     return this.props.findGameId(target);
   }
 }

--- a/src/renderer/components/GameList.tsx
+++ b/src/renderer/components/GameList.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { ArrowKeyStepper, AutoSizer, List, ListRowProps, ScrollIndices } from 'react-virtualized';
-import { RenderedSection } from 'react-virtualized/dist/es/Grid';
 import { IGameInfo } from '../../shared/game/interfaces';
 import { GameImageCollection } from '../image/GameImageCollection';
-import { IDefaultProps } from '../interfaces';
 import { GameListItem } from './GameListItem';
 import { GameOrderBy, GameOrderReverse } from '../../shared/order/interfaces';
 import { findElementAncestor } from '../Util';
@@ -12,41 +10,38 @@ import { GameItemContainer } from './GameItemContainer';
 /** A function that receives an HTML element. */
 type RefFunc<T extends HTMLElement> = (instance: T | null) => void;
 
-export interface IGameListProps extends IDefaultProps {
+export type GameListProps = {
   gameImages: GameImageCollection;
-  /** All games that will be shown in the list */
+  /** All games that will be shown in the list. */
   games?: IGameInfo[];
-  /** Selected game (if any) */
+  /** Currently selected game (if any). */
   selectedGame?: IGameInfo;
-  /** Dragged game (if any) */
+  /** Currently dragged game (if any). */
   draggedGame?: IGameInfo;
-  /** Height of each row/item in the list (in pixels) */
+  /** Height of each row in the list (in pixels). */
   rowHeight: number;
-  /** Function that renders the child(ren) of the game list when it is empty */
+  /** Function that renders the elements to show instead of the grid if there are no games (render prop). */
   noRowsRenderer?: () => JSX.Element;
-  /** Called when a game is selected */
+  /** Called when the user attempts to select a game. */
   onGameSelect?: (game?: IGameInfo) => void;
-  /** Called when a game is launched */
+  /** Called when the user attempts to launch a game. */
   onGameLaunch: (game: IGameInfo) => void;
-  /** Called when a context menu should be opened */
+  /** Called when the user attempts to open a context menu (at a game). */
   onContextMenu?: (game: IGameInfo) => void;
-  /** Called when a game is started being dragged */
+  /** Called when the user starts to drag a game. */
   onGameDragStart?: (event: React.DragEvent, game: IGameInfo) => void;
-  /** Called when a game is ending being dragged */
+  /** Called when the user stops dragging a game (when they release it). */
   onGameDragEnd?: (event: React.DragEvent, game: IGameInfo) => void;
-  // React-Virtualized Pass-through
+  // React-Virtualized pass-through props (their values are not used for anything other than updating the grid when changed)
   orderBy?: GameOrderBy;
   orderReverse?: GameOrderReverse;
-  /** Function for getting a reference to list element. Called whenever the reference could change. */
+  /** Function for getting a reference to grid element. Called whenever the reference could change. */
   listRef?: RefFunc<HTMLDivElement>;
-}
+};
 
-export class GameList extends React.Component<IGameListProps, {}> {
+/** A list of rows, where each rows displays a game. */
+export class GameList extends React.Component<GameListProps, {}> {
   private _wrapper: React.RefObject<HTMLDivElement> = React.createRef();
-
-  constructor(props: IGameListProps) {
-    super(props);
-  }
 
   componentDidMount(): void {
     this.updateCssVars();
@@ -58,59 +53,62 @@ export class GameList extends React.Component<IGameListProps, {}> {
 
   render() {
     const games = this.props.games || [];
-    const rowCount = games.length;
-    // Calculate column and row of selected item
-    let scrollToIndex: number = -1;
-    if (this.props.selectedGame) {
-      scrollToIndex = games.indexOf(this.props.selectedGame);
-    }
     // Render
     return (
-      <GameItemContainer className='game-browser__center__inner'
-                         onGameSelect={this.onGameSelect}
-                         onGameLaunch={this.onGameLaunch}
-                         onGameContextMenu={this.onGameContextMenu}
-                         onGameDragStart={this.onGameDragStart}
-                         onGameDragEnd={this.onGameDragEnd}
-                         findGameId={this.findGameId}
-                         realRef={this._wrapper}
-                         onKeyPress={this.onKeyPress}>
+      <GameItemContainer
+        className='game-browser__center__inner'
+        onGameSelect={this.onGameSelect}
+        onGameLaunch={this.onGameLaunch}
+        onGameContextMenu={this.onGameContextMenu}
+        onGameDragStart={this.onGameDragStart}
+        onGameDragEnd={this.onGameDragEnd}
+        findGameId={this.findGameId}
+        realRef={this._wrapper}
+        onKeyPress={this.onKeyPress}>
         <AutoSizer>
-          {({ width, height }) => (
-            <ArrowKeyStepper
-              onScrollToChange={this.onScrollToChange}
-              mode='cells'
-              isControlled={true}
-              columnCount={1}
-              rowCount={rowCount}
-              scrollToRow={scrollToIndex}>
-              {({ onSectionRendered, scrollToColumn, scrollToRow }) => (
-                <List
-                  className='game-list simple-scroll'
-                  width={width}
-                  height={height}
-                  rowHeight={this.props.rowHeight}
-                  rowCount={rowCount}
-                  overscanRowCount={15}
-                  noRowsRenderer={this.props.noRowsRenderer}
-                  rowRenderer={this.rowRenderer}
-                  // ArrowKeyStepper props
-                  scrollToIndex={scrollToRow}
-                  onRowsRendered={this.onRowsRendered.bind(this, onSectionRendered)}
-                  // Pass-through props (they have no direct effect on the list)
-                  // (If any property is changed the list is re-rendered, even these)
-                  orderBy={this.props.orderBy}
-                  orderReverse={this.props.orderReverse}
-                  />
-              )}
-            </ArrowKeyStepper>
-          )}
+          {({ width, height }) => {
+            // Calculate column and row of selected item
+            const rowCount = games.length;
+            let scrollToIndex: number = -1;
+            if (this.props.selectedGame) {
+              scrollToIndex = games.indexOf(this.props.selectedGame);
+            }
+            return (
+              <ArrowKeyStepper
+                onScrollToChange={this.onScrollToChange}
+                mode='cells'
+                isControlled={true}
+                columnCount={1}
+                rowCount={rowCount}
+                scrollToRow={scrollToIndex}>
+                {({ onSectionRendered, scrollToColumn, scrollToRow }) => (
+                  <List
+                    className='game-list simple-scroll'
+                    width={width}
+                    height={height}
+                    rowHeight={this.props.rowHeight}
+                    rowCount={rowCount}
+                    overscanRowCount={15}
+                    noRowsRenderer={this.props.noRowsRenderer}
+                    rowRenderer={this.rowRenderer}
+                    // ArrowKeyStepper props
+                    scrollToIndex={scrollToRow}
+                    onSectionRendered={onSectionRendered}
+                    // Pass-through props (they have no direct effect on the list)
+                    // (If any property is changed the list is re-rendered, even these)
+                    orderBy={this.props.orderBy}
+                    orderReverse={this.props.orderReverse}
+                    />
+                )}
+              </ArrowKeyStepper>
+            );
+          }}
         </AutoSizer>
       </GameItemContainer>
     );
   }
 
-  /** Renders a single row / list item */
+  /** Renders a single row in the game list. */
   rowRenderer = (props: ListRowProps): React.ReactNode => {
     const { draggedGame, games, gameImages, rowHeight, selectedGame } = this.props;
     if (!games) { throw new Error('Trying to render a row in game list, but no games are found?'); }
@@ -118,18 +116,19 @@ export class GameList extends React.Component<IGameListProps, {}> {
     const game = games[props.index];
     let thumbnail = gameImages.getThumbnailPath(game);
     return (
-      <GameListItem key={props.key}
-                    {...props}
-                    game={game}
-                    thumbnail={thumbnail || ''}
-                    height={rowHeight}
-                    isDraggable={true}
-                    isSelected={game === selectedGame}
-                    isDragged={game === draggedGame} />
+      <GameListItem
+        { ...props }
+        key={props.key}
+        game={game}
+        thumbnail={thumbnail || ''}
+        height={rowHeight}
+        isDraggable={true}
+        isSelected={game === selectedGame}
+        isDragged={game === draggedGame} />
     );
   }
 
-  /** When a key is pressed (while the list, or one of its children, is selected) */
+  /** When a key is pressed (while the list, or one of its children, is selected). */
   onKeyPress = (event: React.KeyboardEvent): void => {
     if (event.key === 'Enter') {
       if (this.props.selectedGame) {
@@ -138,17 +137,18 @@ export class GameList extends React.Component<IGameListProps, {}> {
     }
   }
 
-  /** When a game item is clicked. */
+  /** When a row is clicked. */
   onGameSelect = (event: React.MouseEvent, gameId: string | undefined): void => {
     this.onGameSelected(this.findGame(gameId));
   }
   
-  /** When a list item is double clicked */
+  /** When a row is double clicked. */
   onGameLaunch = (event: React.MouseEvent, gameId: string): void => {
     const game = this.findGame(gameId);
     if (game) { this.props.onGameLaunch(game); }
   }
 
+  /** When a row is right clicked. */
   onGameContextMenu = (event: React.MouseEvent<HTMLDivElement>, gameId: string | undefined): void => {
     if (this.props.onContextMenu) {
       const game = this.findGame(gameId);
@@ -156,7 +156,7 @@ export class GameList extends React.Component<IGameListProps, {}> {
     }
   }
   
-  /** When a list item is started to being dragged. */
+  /** When a row is starting to be dragged. */
   onGameDragStart = (event: React.DragEvent, gameId: string | undefined): void => {
     if (this.props.onGameDragStart) {
       const game = this.findGame(gameId);
@@ -164,7 +164,7 @@ export class GameList extends React.Component<IGameListProps, {}> {
     }
   }
   
-  /** When a list item is ended to being dragged. */
+  /** When a row is ending being dragged. */
   onGameDragEnd = (event: React.DragEvent, gameId: string | undefined): void => {
     if (this.props.onGameDragEnd) {
       const game = this.findGame(gameId);
@@ -172,22 +172,7 @@ export class GameList extends React.Component<IGameListProps, {}> {
     }
   }
 
-  onContextMenu = (event: React.MouseEvent<HTMLElement>): void => {
-    const element = findElementAncestor(event.target as Element, target => GameListItem.isElement(target));
-    if (element) {
-      const id = GameListItem.getId(element);
-      // Get props
-      const { games, onContextMenu } = this.props;
-      if (!games)         { throw new Error('Failed to open context menu. Prop "games" not found.');         }
-      if (!onContextMenu) { throw new Error('Failed to open context menu. Prop "onContextMenu" not found.'); }
-      // Find game and call back
-      const game = games.find(item => item.id === id);
-      if (!game) { throw new Error('Failed to open context menu. Game not found.'); }
-      onContextMenu(game);
-    }
-  }
-
-  /** When a row/item is selected */
+  /** When a row is selected. */
   onScrollToChange = (params: ScrollIndices): void => {
     if (!this.props.games) { throw new Error('Games array is missing.'); }
     if (params.scrollToRow === -1) {
@@ -200,20 +185,7 @@ export class GameList extends React.Component<IGameListProps, {}> {
     }
   }
 
-  /** When the game list renders - argument contains the indices of first/last rows rendered */
-  onRowsRendered = (onSectionRendered: (params: RenderedSection) => void, info: RowsRenderedInfo): void => {
-    onSectionRendered({
-      columnOverscanStartIndex: 0,
-      columnOverscanStopIndex: 0,
-      columnStartIndex: 0,
-      columnStopIndex: 0,
-      rowOverscanStartIndex: info.overscanStartIndex,
-      rowOverscanStopIndex: info.overscanStopIndex,
-      rowStartIndex: info.startIndex,
-      rowStopIndex: info.stopIndex,
-    });
-  }
-
+  /** Wrapper for calling the prop "onGameSelect". */
   onGameSelected(game?: IGameInfo): void {
     if (this.props.onGameSelect) {
       this.props.onGameSelect(game);
@@ -255,12 +227,4 @@ export class GameList extends React.Component<IGameListProps, {}> {
       this.props.listRef(ref);
     }
   }
-}
-
-/** The interface used by the only parameter of List's prop onRowsRendered */
-interface RowsRenderedInfo {
-  overscanStartIndex: number;
-  overscanStopIndex: number;
-  startIndex: number;
-  stopIndex: number;
 }

--- a/src/renderer/components/GameList.tsx
+++ b/src/renderer/components/GameList.tsx
@@ -40,7 +40,7 @@ export type GameListProps = {
 };
 
 /** A list of rows, where each rows displays a game. */
-export class GameList extends React.Component<GameListProps, {}> {
+export class GameList extends React.Component<GameListProps> {
   private _wrapper: React.RefObject<HTMLDivElement> = React.createRef();
 
   componentDidMount(): void {

--- a/src/renderer/components/GameListItem.tsx
+++ b/src/renderer/components/GameListItem.tsx
@@ -1,29 +1,25 @@
 import * as React from 'react';
 import { ListRowProps } from 'react-virtualized';
 import { IGameInfo } from '../../shared/game/interfaces';
-import { IDefaultProps } from '../interfaces';
 import { getPlatformIconPath } from '../Util';
 
-export interface IGameListItemProps extends ListRowProps, IDefaultProps {
-  /** Game to show */
+export type GameListItemProps = ListRowProps & {
+  /** Game to display. */
   game: IGameInfo;
-  /** Path to the games thumbnail */
+  /** Path to the game's thumbnail. */
   thumbnail: string;
-  /** Height of the list item (in pixels) */
+  /** Height of the row (in pixels) */
   height: number;
-  /** If the grid item can be dragged (defaults to false) */
+  /** If the row can be dragged (defaults to false). */
   isDraggable?: boolean;
-  /** If the grid item is selected */
+  /** If the row is selected. */
   isSelected: boolean;
-  /** If the grid item is being dragged */
+  /** If the row is being dragged. */
   isDragged: boolean;
-}
+};
 
-export class GameListItem extends React.Component<IGameListItemProps, {}> {
-  constructor(props: IGameListItemProps) {
-    super(props);
-  }
-
+/** Displays a single game. Meant to be rendered inside a list. */
+export class GameListItem extends React.Component<GameListItemProps, {}> {
   render() {
     const game = this.props.game;
     const title: string = game.title || '';
@@ -39,23 +35,30 @@ export class GameListItem extends React.Component<IGameListItemProps, {}> {
     if (this.props.isDragged)       { className += ' game-list-item--dragged';  }
     // Render
     return (
-      <li style={this.props.style}
-          className={className} 
-          draggable={this.props.isDraggable}
-          { ...attributes }>
-        <div className='game-list-item__thumb' style={{
-          backgroundImage: `url("${this.props.thumbnail}")`,
-          width: size,
-          height: size,
-        }} />
+      <li
+        style={this.props.style}
+        className={className} 
+        draggable={this.props.isDraggable}
+        { ...attributes }>
+        <div
+          className='game-list-item__thumb'
+          style={{
+            backgroundImage: `url("${this.props.thumbnail}")`,
+            width: size,
+            height: size,
+          }} />
         <div className='game-list-item__right'>
-          <p className='game-list-item__right__title' title={title}>{title}</p>
+          <p
+            className='game-list-item__right__title'
+            title={title}>
+            {title}
+          </p>
           <p className='game-list-item__right__genre'>{game.genre}</p>
           <div className='game-list-item__right__icons'>
             {(platformIcon) ? (
-              <div className='game-list-item__right__icons__icon' style={{
-                backgroundImage: `url("${platformIcon}")`
-              }} />
+              <div
+                className='game-list-item__right__icons__icon'
+                style={{ backgroundImage: `url("${platformIcon}")` }} />
             ) : undefined }
           </div>
         </div>

--- a/src/renderer/components/GameListItem.tsx
+++ b/src/renderer/components/GameListItem.tsx
@@ -19,7 +19,7 @@ export type GameListItemProps = ListRowProps & {
 };
 
 /** Displays a single game. Meant to be rendered inside a list. */
-export class GameListItem extends React.Component<GameListItemProps, {}> {
+export class GameListItem extends React.Component<GameListItemProps> {
   render() {
     const game = this.props.game;
     const title: string = game.title || '';

--- a/src/renderer/components/GameOrder.tsx
+++ b/src/renderer/components/GameOrder.tsx
@@ -1,28 +1,33 @@
 import * as React from 'react';
-import { IDefaultProps } from '../interfaces';
 import { GameOrderBy, GameOrderReverse } from '../../shared/order/interfaces';
 
-export interface IGameOrderProps extends IDefaultProps {
-  onChange?: (event: IGameOrderChangeEvent) => void;
+export type GameOrderProps = {
+  /** Called when the either the property to order by, or what way to order in, is changed. */
+  onChange?: (event: GameOrderChangeEvent) => void;
+  /** What property to order the games by. */
+  orderBy: GameOrderBy;
+  /** What way to order the games in. */
+  orderReverse: GameOrderReverse;
+};
+
+export type GameOrderChangeEvent = {
   orderBy: GameOrderBy;
   orderReverse: GameOrderReverse;
-}
+};
 
-export interface IGameOrderChangeEvent {
-  orderBy: GameOrderBy;
-  orderReverse: GameOrderReverse;
-}
-
-export class GameOrder extends React.Component<IGameOrderProps> {
-  constructor(props: IGameOrderProps) {
-    super(props);
-  }
-
+/**
+ * Two drop down lists, the first for selecting what to order the games by, and
+ * the second for selecting what way to order the games in.
+ */
+export class GameOrder extends React.Component<GameOrderProps> {
   render() {
     return (
       <>
         {/* Order By */}
-        <select className='simple-selector' value={this.props.orderBy} onChange={this.onOrderByChange}>
+        <select
+          className='simple-selector'
+          value={this.props.orderBy}
+          onChange={this.onOrderByChange}>
           <option value='dateAdded'>Date Added</option>
           <option value='genre'>Genre</option>
           <option value='platform'>Platform</option>
@@ -30,7 +35,10 @@ export class GameOrder extends React.Component<IGameOrderProps> {
           <option value='title'>Title</option>
         </select>
         {/* Order Reverse */}
-        <select className='simple-selector' value={this.props.orderReverse} onChange={this.onOrderReverseChange}>
+        <select
+          className='simple-selector'
+          value={this.props.orderReverse}
+          onChange={this.onOrderReverseChange}>
           <option value='ascending'>Ascending</option>
           <option value='descending'>Descending</option>
         </select>
@@ -38,19 +46,19 @@ export class GameOrder extends React.Component<IGameOrderProps> {
     );
   }
 
-  private onOrderByChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+  onOrderByChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
     this.updateOrder({
-      orderBy: this.parseOrderBy(event.target.value),
+      orderBy: validateOrderBy(event.target.value),
     });
   }
 
-  private onOrderReverseChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+  onOrderReverseChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
     this.updateOrder({
-      orderReverse: this.parseOrderReverse(event.target.value),
+      orderReverse: validateOrderReverse(event.target.value),
     });
   }
 
-  private updateOrder(data: Partial<IGameOrderChangeEvent>): void {
+  updateOrder(data: Partial<GameOrderChangeEvent>): void {
     if (this.props.onChange) {
       this.props.onChange({
         orderBy:      data.orderBy      || this.props.orderBy,
@@ -59,24 +67,33 @@ export class GameOrder extends React.Component<IGameOrderProps> {
     }
   }
 
-  /** Parse GameOrderBy from a string (error if invalid) */
-  private parseOrderBy(value: string): GameOrderBy {
-    switch (value) {
-      case 'dateAdded': return 'dateAdded';
-      case 'genre':     return 'genre';
-      case 'platform':  return 'platform';
-      case 'series':    return 'series';
-      case 'title':     return 'title';
-      default: throw new Error(`"${value}" is not a valid GameOrderBy`);
-    }
-  }
+}
 
-  /** Parse GameOrderReverse from a string (error if invalid) */
-  private parseOrderReverse(value: string): GameOrderReverse {
-    switch (value) {
-      case 'ascending':  return 'ascending';
-      case 'descending': return 'descending';
-      default: throw new Error(`"${value}" is not a valid GameOrderReverse`);
-    }
+/**
+ * Validate a value to be a "GameOrderBy" string (throws an error if invalid).
+ * @param value Value to validate.
+ * @returns The same value as the first argument.
+ */
+function validateOrderBy(value: string): GameOrderBy {
+  switch (value) {
+    case 'dateAdded': return 'dateAdded';
+    case 'genre':     return 'genre';
+    case 'platform':  return 'platform';
+    case 'series':    return 'series';
+    case 'title':     return 'title';
+    default: throw new Error(`"${value}" is not a valid GameOrderBy`);
+  }
+}
+
+/**
+ * Validate a value to be a "GameOrderReverse" string (throws an error if invalid).
+ * @param value Value to validate.
+ * @returns The same value as the first argument.
+ */
+function validateOrderReverse(value: string): GameOrderReverse {
+  switch (value) {
+    case 'ascending':  return 'ascending';
+    case 'descending': return 'descending';
+    default: throw new Error(`"${value}" is not a valid GameOrderReverse`);
   }
 }

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -5,28 +5,36 @@ import { WithPreferencesProps } from '../containers/withPreferences';
 import { Paths } from '../Paths';
 import { SearchQuery } from '../store/search';
 import { easterEgg, joinLibraryRoute } from '../Util';
-import { GameOrder, IGameOrderChangeEvent } from './GameOrder';
+import { GameOrder, GameOrderChangeEvent } from './GameOrder';
 import { OpenIcon } from './OpenIcon';
 
-interface OwnProps {
+type OwnProps = {
+  /** The most recent search query. */
   searchQuery: SearchQuery;
-  order: IGameOrderChangeEvent;
+  /** The current parameters for ordering games. */
+  order: GameOrderChangeEvent;
+  /** Called when a search is made. */
   onSearch: (text: string, redirect: boolean) => void;
-  onOrderChange?: (event: IGameOrderChangeEvent) => void;
+  /** Called when any of the ordering parameters are changed (by the header or a sub-component). */
+  onOrderChange?: (event: GameOrderChangeEvent) => void;
+  /** Called when the left sidebar toggle button is clicked. */
   onToggleLeftSidebarClick?: () => void;
+  /** Called when the right sidebar toggle button is clicked. */
   onToggleRightSidebarClick?: () => void;
-}
+};
 
-export type IHeaderProps = OwnProps & RouteComponentProps & WithPreferencesProps & WithLibraryProps;
+export type HeaderProps = OwnProps & RouteComponentProps & WithPreferencesProps & WithLibraryProps;
 
-export interface IHeaderState {
+type HeaderState = {
+  /** Current text in the search field. */
   searchText: string;
-}
+};
 
-export class Header extends React.Component<IHeaderProps, IHeaderState> {
-  private searchInputRef: React.RefObject<HTMLInputElement> = React.createRef();
+/** The header that is always visible at the top of the main window (just below the title bar). */
+export class Header extends React.Component<HeaderProps, HeaderState> {
+  searchInputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
-  constructor(props: IHeaderProps) {
+  constructor(props: HeaderProps) {
     super(props);
     this.state = {
       searchText: this.props.searchQuery.text,
@@ -53,20 +61,32 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
         {/* Header Menu */}
         <div className='header__wrap'>
           <ul className='header__menu'>
-            <MenuItem title='Home' link={Paths.HOME}/>
+            <MenuItem title='Home' link={Paths.HOME} />
             { libraries.length > 0 ? (
               libraries.map(item => (
-                <MenuItem title={item.title} link={joinLibraryRoute(item.route)}
-                          key={item.route}/>
+                <MenuItem
+                  key={item.route}
+                  title={item.title}
+                  link={joinLibraryRoute(item.route)} />
               )) 
             ) : (
-              <MenuItem title='Browse' link={Paths.BROWSE}/>
+              <MenuItem
+                title='Browse'
+                link={Paths.BROWSE} />
             ) }
-            <MenuItem title='Logs' link={Paths.LOGS}/>
-            <MenuItem title='Config' link={Paths.CONFIG}/>
-            <MenuItem title='About' link={Paths.ABOUT}/>
+            <MenuItem
+              title='Logs'
+              link={Paths.LOGS} />
+            <MenuItem
+              title='Config'
+              link={Paths.CONFIG} />
+            <MenuItem
+              title='About'
+              link={Paths.ABOUT} />
             { showDeveloperTab ? (
-              <MenuItem title='Developer' link={Paths.DEVELOPER}/>
+              <MenuItem
+                title='Developer'
+                link={Paths.DEVELOPER} />
             ) : undefined }
           </ul>
         </div>
@@ -75,14 +95,21 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
           <div>
             <div className='header__search'>
               <div className='header__search__left'>
-                <input className='header__search__input' ref={this.searchInputRef}
-                       value={searchText} placeholder='Search...'
-                       onChange={this.onSearchChange} onKeyDown={this.onSearchKeyDown} />                
+                <input
+                  className='header__search__input'
+                  ref={this.searchInputRef}
+                  value={searchText}
+                  placeholder='Search...'
+                  onChange={this.onSearchChange}
+                  onKeyDown={this.onSearchKeyDown} />                
               </div>
-              <div className='header__search__right'
-                   onClick={ searchText ? this.onClearClick : undefined }>
+              <div
+                className='header__search__right'
+                onClick={ searchText ? this.onClearClick : undefined }>
                 <div className='header__search__right__inner'>
-                  <OpenIcon className='header__search__icon' icon={ searchText ? 'circle-x' : 'magnifying-glass' } />
+                  <OpenIcon
+                    className='header__search__icon'
+                    icon={ searchText ? 'circle-x' : 'magnifying-glass' } />
                 </div>
               </div>
             </div>
@@ -91,24 +118,27 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
         {/* Header Drop-downs */}
         <div className='header__wrap'>
           <div>
-            <GameOrder onChange={onOrderChange}
-                       orderBy={this.props.order.orderBy}
-                       orderReverse={this.props.order.orderReverse}/>
+            <GameOrder
+              onChange={onOrderChange}
+              orderBy={this.props.order.orderBy}
+              orderReverse={this.props.order.orderReverse} />
           </div>
         </div>
         {/* Right-most portion */}
         <div className='header__wrap header__right'>
           <div>
             {/* Toggle Right Sidebar */}
-            <div className='header__toggle-sidebar'
-                 title={browsePageShowRightSidebar ? 'Hide right sidebar' : 'Show right sidebar'}
-                 onClick={onToggleRightSidebarClick}>
+            <div
+              className='header__toggle-sidebar'
+              title={browsePageShowRightSidebar ? 'Hide right sidebar' : 'Show right sidebar'}
+              onClick={onToggleRightSidebarClick}>
               <OpenIcon icon={browsePageShowRightSidebar ? 'collapse-right' : 'expand-right'} />
             </div>
             {/* Toggle Left Sidebar */}
-            <div className='header__toggle-sidebar'
-                 title={browsePageShowLeftSidebar ? 'Hide left sidebar' : 'Show left sidebar'}
-                 onClick={onToggleLeftSidebarClick}>
+            <div
+              className='header__toggle-sidebar'
+              title={browsePageShowLeftSidebar ? 'Hide left sidebar' : 'Show left sidebar'}
+              onClick={onToggleLeftSidebarClick}>
               <OpenIcon icon={browsePageShowLeftSidebar ? 'collapse-left' : 'expand-left'} />
             </div>
           </div>
@@ -117,14 +147,14 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
     );
   }
 
-  private onSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  onSearchChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const value = event.target.value;
     this.setState({ searchText: value });
     // "Clear" the search when the search field gets empty
     if (value === '') { this.props.onSearch('', false); }
   }
 
-  private onSearchKeyDown = (event: React.KeyboardEvent): void => {
+  onSearchKeyDown = (event: React.KeyboardEvent): void => {
     if (event.key === 'Enter') {
       const value = this.state.searchText;
       this.props.onSearch(value, true);
@@ -132,7 +162,7 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
     }
   }
 
-  private onKeypress = (event: KeyboardEvent): void => {
+  onKeypress = (event: KeyboardEvent): void => {
     if (event.ctrlKey && event.code === 'KeyF') {
       const element = this.searchInputRef.current;
       if (element) {
@@ -142,12 +172,14 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
     }
   }
 
-  private onClearClick = (): void => {
+  onClearClick = (): void => {
     this.setState({ searchText: '' });
     this.props.onSearch('', false);
   }
 }
 
+
+/** An item in the header menu. Used as buttons to switch between tabs/pages. */
 function MenuItem({ title, link }: { title: string, link: string }) {
   return (
     <li className='header__menu__item'>

--- a/src/renderer/components/ImagePreview.tsx
+++ b/src/renderer/components/ImagePreview.tsx
@@ -1,32 +1,35 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-export interface IImagePreviewProps {
-  /** Source of the image to show */
+export type ImagePreviewProps = {
+  /** Source of the image to display. */
   src?: string;
-  /** Called when the image preview should be cancelled */
+  /** Called when the user attempts to cancel/close image preview. */
   onCancel?: () => void;
-}
+};
 
-export interface IImagePreviewState {
-  /** If the image should be scaled up if its smaller than the size it can take up */
+export type ImagePreviewState = {
+  /** If the image should be scaled up to fill the entire preview space (if it is smaller than that space). */
   scaleUp: boolean;
-  /** Original width of image */
+  /** Original width of image (in pixels). */
   imageWidth: number;
-  /** Original height of image */
+  /** Original height of image (in pixels). */
   imageHeight: number;
-  /** Width of border */
+  /** Width of border (in pixels). The border is the area between the preview space and the edge of the window. */
   borderWidth: number;
-  /** Height of border */
+  /** Height of border (in pixels). The border is the area between the preview space and the edge of the window. */
   borderHeight: number;
-}
+};
 
-export class ImagePreview extends React.Component<IImagePreviewProps, IImagePreviewState> {
-  private borderRef: React.RefObject<HTMLDivElement> = React.createRef();
-  private parent: HTMLElement;
-  private element: HTMLElement;
+/** An overlay that covers the entire window and displays an image in the center. */
+export class ImagePreview extends React.Component<ImagePreviewProps, ImagePreviewState> {
+  borderRef: React.RefObject<HTMLDivElement> = React.createRef();
+  /** Parent element of the overlay root element. */
+  parent: HTMLElement;
+  /** Root element of the overlay. */
+  element: HTMLElement;
 
-  constructor(props: IImagePreviewProps) {
+  constructor(props: ImagePreviewProps) {
     super(props);
     this.state = {
       scaleUp: false,
@@ -39,7 +42,7 @@ export class ImagePreview extends React.Component<IImagePreviewProps, IImagePrev
     this.element = document.createElement('div');
   }
 
-  componentDidUpdate(prevProps: IImagePreviewProps, prevState: IImagePreviewState) {
+  componentDidUpdate(prevProps: ImagePreviewProps, prevState: ImagePreviewState) {
     if (this.props.src !== prevProps.src) {
       this.updateBorderSize();
     }
@@ -57,22 +60,31 @@ export class ImagePreview extends React.Component<IImagePreviewProps, IImagePrev
   }
 
   render() {
-    const { scaleUp } = this.state;
-    return ReactDOM.createPortal(
-      (<div className='image-preview' onClick={this.onClickBackground}>
-        <div className='image-preview__border simple-center' onClick={this.onClickBackground} ref={this.borderRef}>
-          <div className='simple-center__inner simple-center__vertical-inner' onClick={this.onClickBackground}>
-            <img className={'image-preview__image' + (scaleUp ? ' image-preview__image--fill' : ' image-preview__image--fit')}
-                 src={this.props.src} onClick={this.onClickImage} onLoad={this.onLoad} style={{...this.calculateSize()}} />
+    return ReactDOM.createPortal((
+      <div
+        className='image-preview'
+        onClick={this.onClickBackground}>
+        <div
+          className='image-preview__border simple-center'
+          onClick={this.onClickBackground}
+          ref={this.borderRef}>
+          <div
+            className='simple-center__inner simple-center__vertical-inner'
+            onClick={this.onClickBackground}>
+            <img
+              className={'image-preview__image' + (this.state.scaleUp ? ' image-preview__image--fill' : ' image-preview__image--fit')}
+              src={this.props.src}
+              onClick={this.onClickImage}
+              onLoad={this.onLoad}
+              style={{ ...this.calculateSize() }} />
           </div>
         </div>
-      </div>),
-      this.element,
-    );
+      </div>
+    ), this.element);
   }
 
-  /** Calculate the size the image should have, depending on the current state */
-  private calculateSize(): { width: number, height: number } {
+  /** Calculate the size the image should have, depending on the current state. */
+  calculateSize(): { width: number, height: number } {
     const { scaleUp, imageWidth, imageHeight, borderWidth, borderHeight } = this.state;
     let width = imageWidth;
     let height = imageHeight;
@@ -84,17 +96,17 @@ export class ImagePreview extends React.Component<IImagePreviewProps, IImagePrev
     return { width, height };
   }
 
-  private onClickImage = (): void => {
+  onClickImage = (): void => {
     this.setState({ scaleUp: !this.state.scaleUp });
   }
 
-  private onClickBackground = (event: React.MouseEvent): void => {
+  onClickBackground = (event: React.MouseEvent): void => {
     if (event.target === event.currentTarget) {
       if (this.props.onCancel) { this.props.onCancel(); }
     }
   }
 
-  private updateBorderSize = (): void => {
+  updateBorderSize = (): void => {
     const border = this.borderRef.current;
     if (!border) { throw new Error('Border is missing.'); }
     this.setState({
@@ -103,7 +115,7 @@ export class ImagePreview extends React.Component<IImagePreviewProps, IImagePrev
     });
   }
   
-  private onLoad = (event: React.SyntheticEvent<HTMLImageElement>): void => {
+  onLoad = (event: React.SyntheticEvent<HTMLImageElement>): void => {
     this.setState({
       imageWidth: event.currentTarget.naturalWidth,
       imageHeight: event.currentTarget.naturalHeight,

--- a/src/renderer/components/InputField.tsx
+++ b/src/renderer/components/InputField.tsx
@@ -1,47 +1,65 @@
 import * as React from 'react';
 
-type InputElement = HTMLInputElement|HTMLTextAreaElement;
+/** Input element types used by this component. */
+type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
-export interface InputFieldProps {
+export type InputFieldProps = {
+  /** Current text. */
   text: string;
+  /** Placeholder text (used to set the "placeholder" attribute). */
   placeholder?: string;
+  /** If the text can be edited. */
   canEdit?: boolean;
+  /** If the text field should support multi-line text. */
   multiline?: boolean;
+  /** Class names of the element. */
   className?: string;
+  /** Reference of the element. */
   reference?: React.RefObject<any>;
+  /** Called when the text has been changed. */
   onChange?: (event: React.ChangeEvent<InputElement>) => void;
+  /** Called when a key is pressed. */
   onKeyDown?: (event: React.KeyboardEvent<InputElement>) => void;
-}
+};
 
+/** A generic input field. */
 export function InputField(props: InputFieldProps) {
   const { canEdit, className, multiline, onChange, onKeyDown, placeholder, reference, text } = props;
+  const cleanClassName = (className ? ' '+className : '');
   if (canEdit) {
     if (multiline) {
       return (
-        <textarea value={text} placeholder={placeholder} ref={reference}
-                  onChange={onChange || noop} onKeyDown={onKeyDown || noop}
-                  className={'input-field input-field--multiline input-field--edit simple-input simple-scroll'+
-                             (className ? ' '+className : '')} />
+        <textarea
+          value={text}
+          placeholder={placeholder}
+          ref={reference}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          className={'input-field input-field--multiline input-field--edit simple-input simple-scroll' + cleanClassName} />
       );
     } else {
       return (
-        <input value={text} placeholder={placeholder} ref={reference}
-               onChange={onChange || noop} onKeyDown={onKeyDown || noop}
-               className={'input-field input-field--edit simple-input'+
-                          (className ? ' '+className : '')} />
+        <input
+          value={text}
+          placeholder={placeholder}
+          ref={reference}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          className={'input-field input-field--edit simple-input' + cleanClassName} />
       );
     }
   } else {
     let cn = 'input-field';
-    if (!text)     { cn += ' simple-disabled-text'; }
+    if (!text)     { cn += ' simple-disabled-text';   }
     if (multiline) { cn += ' input-field--multiline'; }
-    if (className) { cn += ' '+className; }
+    if (className) { cn += cleanClassName;            }
     return (
-      <p title={props.text} className={cn} ref={reference}>
+      <p
+        title={props.text}
+        className={cn}
+        ref={reference}>
         {props.text || props.placeholder}
       </p>
     );
   }
 }
-
-const noop = () => {};

--- a/src/renderer/components/LeftBrowseSidebar.tsx
+++ b/src/renderer/components/LeftBrowseSidebar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ICentralState } from '../interfaces';
+import { CentralState } from '../interfaces';
 import { PlaylistItem } from './PlaylistItem';
 import { OpenIcon } from './OpenIcon';
 import { IGamePlaylist } from '../playlist/interfaces';
@@ -7,26 +7,33 @@ import { gameIdDataType } from '../Util';
 import { WithPreferencesProps } from '../containers/withPreferences';
 import { IGameLibraryFileItem } from '../../shared/library/interfaces';
 
-interface OwnProps {
-  central: ICentralState;
+type OwnProps = {
+  /** Semi-global prop. */
+  central: CentralState;
+  /** The current library. */
   currentLibrary?: IGameLibraryFileItem;
-  /** ID of the playlist that is selected (empty string if none) */
+  /** ID of the playlist that is selected (empty string if none). */
   selectedPlaylistID: string;
+  /** Called when a playlist is selected. */
   onSelectPlaylist?: (playlist: IGamePlaylist) => void;
+  /** Called when a the current playlist is deselected (and no playlist is selected in its place). */
   onDeselectPlaylist?: () => void;
+  /** Called when a displayed playlist has been changed (by means that doesn't already re-render). */
   onPlaylistChanged?: (playlist: IGamePlaylist) => void;
+  /** Called when the "Show All" button is clicked. */
   onShowAllClick?: () => void;
-}
+};
 
-export type ILeftBrowseSidebarProps = OwnProps & WithPreferencesProps;
+export type LeftBrowseSidebarProps = OwnProps & WithPreferencesProps;
 
-export interface ILeftBrowseSidebarState {
+type LeftBrowseSidebarState = {
+  /** If the selected playlist is being edited. */
   isEditing: boolean;
-}
+};
 
-/** Sidebar on the left side of BrowsePage */
-export class LeftBrowseSidebar extends React.Component<ILeftBrowseSidebarProps, ILeftBrowseSidebarState> {
-  constructor(props: ILeftBrowseSidebarProps) {
+/** Sidebar on the left side of BrowsePage. */
+export class LeftBrowseSidebar extends React.Component<LeftBrowseSidebarProps, LeftBrowseSidebarState> {
+  constructor(props: LeftBrowseSidebarProps) {
     super(props);
     this.state = {
       isEditing: false,
@@ -59,7 +66,9 @@ export class LeftBrowseSidebar extends React.Component<ILeftBrowseSidebarProps, 
             !central.playlistsFailedLoading ? (
               <div className='playlist-list'>
                 {/* All games */}
-                <div className='playlist-list-fake-item' onClick={onShowAllClick}>
+                <div
+                  className='playlist-list-fake-item'
+                  onClick={onShowAllClick}>
                   <div className='playlist-list-fake-item__inner'>
                     <OpenIcon icon='eye' />
                   </div>
@@ -71,23 +80,26 @@ export class LeftBrowseSidebar extends React.Component<ILeftBrowseSidebarProps, 
                 {playlists.map((playlist) => {
                   const isSelected = playlist.id === selectedPlaylistID;
                   return (
-                    <PlaylistItem key={playlist.id} 
-                                  playlist={playlist}
-                                  expanded={isSelected}
-                                  editingDisabled={editingDisabled}
-                                  editing={isSelected && isEditing}
-                                  central={central}
-                                  onHeadClick={this.onPlaylistItemHeadClick}
-                                  onEditClick={this.onPlaylistItemEditClick}
-                                  onDeleteClick={this.onPlaylistItemDeleteClick}
-                                  onSaveClick={this.onPlaylistItemSaveClick}
-                                  onDrop={this.onPlaylistItemDrop}
-                                  onDragOver={this.onPlaylistItemDragOver} />
+                    <PlaylistItem
+                      key={playlist.id} 
+                      playlist={playlist}
+                      expanded={isSelected}
+                      editingDisabled={editingDisabled}
+                      editing={isSelected && isEditing}
+                      central={central}
+                      onHeadClick={this.onPlaylistItemHeadClick}
+                      onEditClick={this.onPlaylistItemEditClick}
+                      onDeleteClick={this.onPlaylistItemDeleteClick}
+                      onSaveClick={this.onPlaylistItemSaveClick}
+                      onDrop={this.onPlaylistItemDrop}
+                      onDragOver={this.onPlaylistItemDragOver} />
                   );
                 })}
                 {/* Create New Playlist */}
                 { editingDisabled ? undefined : (
-                  <div className='playlist-list-fake-item' onClick={this.onCreatePlaylistClick}>
+                  <div
+                    className='playlist-list-fake-item'
+                    onClick={this.onCreatePlaylistClick}>
                     <div className='playlist-list-fake-item__inner'>
                       <OpenIcon icon='plus' />
                     </div>

--- a/src/renderer/components/LogData.tsx
+++ b/src/renderer/components/LogData.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 
-export interface ILogDataProps {
+export type LogDataProps = {
   className?: string;
+  /** Text to show in the log. */
   logData: string;
-  /** If the "logData" should be displayed as HTML or plain text (defaults to plain text) */
+  /** If the "logData" should be displayed as HTML or plain text (defaults to plain text). */
   isLogDataHTML?: boolean;
-}
+};
 
-export interface ILogDataSnapshot {
+type LogDataSnapshot = {
   scrolledToBottom: boolean;
-}
+};
 
 /**
  * Renders the log data.
@@ -18,14 +19,14 @@ export interface ILogDataSnapshot {
  * scrolling is automatically disabled when the user scrolls up, and
  * automatically re-enabled when the user scrolls all the way down.
  */
-export class LogData extends React.Component<ILogDataProps> {
-  private preNodeRef = React.createRef<HTMLPreElement>();
+export class LogData extends React.Component<LogDataProps> {
+  preNodeRef = React.createRef<HTMLPreElement>();
 
   /**
    * Detect if we are scrolled all the way to the bottom before the logs are
    * updated. The return value is passed on the componentDidUpdate.
    */
-  getSnapshotBeforeUpdate(): ILogDataSnapshot | null {
+  getSnapshotBeforeUpdate(): LogDataSnapshot | null {
     const preNode = this.preNodeRef.current;
     if (!preNode) { throw Error('<pre> is not mounted'); }
     return {
@@ -47,29 +48,31 @@ export class LogData extends React.Component<ILogDataProps> {
    * before the update.
    * @param snapshot The return value of `getSnapshotBeforeUpdate`
    */
-  componentDidUpdate(prevProps: ILogDataProps, prevState: {}, snapshot: ILogDataSnapshot) {
-    if (snapshot === null) { return; }
-    if (!snapshot.scrolledToBottom) { return; }
-    this.scrollAllTheDown();
+  componentDidUpdate(prevProps: LogDataProps, prevState: {}, snapshot: LogDataSnapshot) {
+    if (snapshot && snapshot.scrolledToBottom) {
+      this.scrollAllTheDown();
+    }
   }
-
-  private scrollAllTheDown() {
+  
+  /** Scroll to the bottom of the log (jumping to the latest logged data). */
+  scrollAllTheDown() {
     const preNode = this.preNodeRef.current;
-    if (!preNode) throw Error('<pre> is not mounted');
+    if (!preNode) { throw new Error('<pre> is not mounted'); }
     preNode.scrollTop = preNode.scrollHeight;
   }
 
   render() {
     const { className, logData, isLogDataHTML } = this.props;
-    const logContent =  isLogDataHTML ? {
-      dangerouslySetInnerHTML: { __html: this.props.logData }
-    } : {
-      children: logData
-    };
+    // Render the log content as html or as plain text
+    const logContent = isLogDataHTML ?
+      { dangerouslySetInnerHTML: { __html: this.props.logData } } :
+      { children: logData };
+    // Render
     return (
-      <pre className={(className||'')+' log simple-scroll'}
-           ref={this.preNodeRef}
-           {...logContent} />
+      <pre
+        className={(className || '') + ' log simple-scroll'}
+        ref={this.preNodeRef}
+        { ...logContent } />
     );
   }
 }

--- a/src/renderer/components/OpenIcon.tsx
+++ b/src/renderer/components/OpenIcon.tsx
@@ -1,27 +1,35 @@
 import * as React from 'react';
 
-export interface IIconProps {
+export type IconProps = {
+  /** The icon to display. */
   icon: OpenIconType;
+  /** CSS class name(s) of the <svg> element. */
   className?: string;
+  /** CSS class name(s) of the <use> element. */
   useClassName?: string;
-  shapeRendering?: string|number;
+  /** Shape rendering attribute of the <svg> element. */
+  shapeRendering?: string | number;
+  /** Miscellaneous props for the <svg> element (these overrides all the other props). */
   props?: React.HTMLAttributes<SVGElement>;
 };
 
-/** A SVG Icon from the "Open Iconic" collection */
-export const OpenIcon = function(props: IIconProps) {
+/** A SVG Icon from the "Open Iconic" collection. */
+export function OpenIcon (props: IconProps) {
   return (
-    <svg viewBox='0 0 8 8' shapeRendering={props.shapeRendering}
-         className={`icon icon--${props.icon} ${props.className||''}`}
-         {...props.props}>
-      <use xlinkHref={`svg/open-iconic.svg#${props.icon}`}
-           className={`icon__use icon__use--${props.icon} ${props.useClassName||''}`} />
+    <svg
+      viewBox='0 0 8 8'
+      shapeRendering={props.shapeRendering}
+      className={`icon icon--${props.icon} ${props.className || ''}`}
+      { ...props.props }>
+      <use
+        xlinkHref={`svg/open-iconic.svg#${props.icon}`}
+        className={`icon__use icon__use--${props.icon} ${props.useClassName || ''}`} />
     </svg>
   );
 }
 
-/** An icon from the "Open Iconic" collection */
-export type OpenIconType =
+/** An icon from the "Open Iconic" collection. */
+export type OpenIconType = (
     'account-login'
   | 'account-logout'
   | 'action-redo'
@@ -244,4 +252,5 @@ export type OpenIconType =
   | 'x'
   | 'yen'
   | 'zoom-in'
-  | 'zoom-out';
+  | 'zoom-out'
+);

--- a/src/renderer/components/PlaylistItem.tsx
+++ b/src/renderer/components/PlaylistItem.tsx
@@ -41,6 +41,7 @@ type PlaylistItemState = {
   dragOver: boolean;
 };
 
+/** Displays the information about a single playlist. Meant to be used in a list. */
 export class PlaylistItem extends React.Component<PlaylistItemProps, PlaylistItemState> {
   //
   onTitleEditDone        = this.wrapOnEditDone((edit, text) => { edit.title = text; });
@@ -89,7 +90,6 @@ export class PlaylistItem extends React.Component<PlaylistItemProps, PlaylistIte
   }
 
   render() {
-    // Normal rendering stuff
     const playlist = this.state.editPlaylist || this.props.playlist;
     const expanded = !!this.props.expanded;
     const editingDisabled = !!this.props.editingDisabled;

--- a/src/renderer/components/RandomGames.tsx
+++ b/src/renderer/components/RandomGames.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { filterBroken, filterExtreme } from '../../shared/game/GameFilter';
 import { IGameInfo } from '../../shared/game/interfaces';
 import { GameImageCollection } from '../image/GameImageCollection';
@@ -6,57 +7,63 @@ import { shuffle, findElementAncestor } from '../Util';
 import { GameGridItem } from './GameGridItem';
 import { GameItemContainer } from './GameItemContainer';
 
-interface IRandomGamesProps {
+type RandomGamesProps = {
+  /** Games to randomly pick from. */
   games: IGameInfo[];
+  /** Game image collection to get the images from. */
   gameImages: GameImageCollection;
+  /** Called when the user attempts to launch a game. */
   onLaunchGame: (game: IGameInfo) => void;
+  /** If extreme games could be picked and displayed. */
   showExtreme: boolean;
+  /** If broken games could be picked and displayed. */
   showBroken: boolean;
+};
+
+/** The number of games shown in the RandomGames component. */
+const numberOfGames = 6;
+
+/** A small "grid" of randomly selected games. */
+export function RandomGames(props: RandomGamesProps) {
+  // Select random games to display
+  const randomGames = useMemo(() => {
+    const filteredGames = filterBroken(props.showBroken, filterExtreme(props.showExtreme, props.games));
+    const shuffledGames = shuffle(filteredGames);
+    const randomGames = shuffledGames.slice(0, Math.min(numberOfGames, props.games.length));
+    return randomGames;
+  }, [/* Only pick games on the first render. */]);
+  // Launch Callback
+  const onGameLaunch = useCallback((event: React.MouseEvent, gameId: string) => {
+    const game = randomGames.find(game => game.id === gameId);
+    if (game) { props.onLaunchGame(game); }
+  }, []);
+  // Render games
+  const gameItems = React.useMemo(() => (
+    randomGames.map(game => (
+      <GameGridItem
+        key={game.id}
+        game={game}
+        thumbnail={props.gameImages.getThumbnailPath(game) || ''}
+        isSelected={false}
+        isDragged={false} />
+    ))
+  ), [randomGames, props.gameImages]);
+  // Render
+  return (
+    <GameItemContainer
+      className='random-games'
+      onGameLaunch={onGameLaunch}
+      findGameId={findGameId}>
+      { gameItems }
+    </GameItemContainer>
+  );
 }
 
 /**
- * List of random games.
- *
- * This is a React.PureComponent to prevent it from re-rendering when it's
- * props didn't change. Otherwise it would regenerate the list when you e.g.
- * launch one of the games.
+ * Try getting a game ID by checking an element and all of its ancestors.
+ * @param element Element or sub-element of a game.
  */
-export class RandomGames extends React.PureComponent<IRandomGamesProps> {
-  private static amountOfRandomGames = 6;
-
-  private selectRandomGames() {
-    const { games, showExtreme, showBroken } = this.props;
-    const filteredGames = filterBroken(showBroken, filterExtreme(showExtreme, games));
-    const shuffledGames = shuffle(filteredGames);
-    const randomGames = shuffledGames.slice(0, Math.min(RandomGames.amountOfRandomGames, games.length));
-    return randomGames;
-  }
-
-  render() {
-    const { gameImages, onLaunchGame } = this.props;
-    const randomGames = this.selectRandomGames();
-    return (
-      <GameItemContainer className='random-games'
-                         onGameLaunch={(event, gameId) => {
-                           const game = randomGames.find(game => game.id === gameId);
-                           if (game) { onLaunchGame(game); }
-                         }}
-                         findGameId={this.findGameId}>
-        {randomGames.map(game => (
-          <GameGridItem
-            key={game.id}
-            game={game}
-            thumbnail={gameImages.getThumbnailPath(game) || ''}
-            isSelected={false}
-            isDragged={false} />
-        ))}
-      </GameItemContainer>
-    );
-  }
-
-  /** Find a game's ID. */
-  private findGameId = (element: EventTarget): string | undefined => {
-    const game = findElementAncestor(element as Element, target => GameGridItem.isElement(target), true);
-    if (game) { return GameGridItem.getId(game); }
-  }
+function findGameId(element: EventTarget): string | undefined {
+  const game = findElementAncestor(element as Element, target => GameGridItem.isElement(target), true);
+  if (game) { return GameGridItem.getId(game); }
 }

--- a/src/renderer/components/ResizableSidebar.tsx
+++ b/src/renderer/components/ResizableSidebar.tsx
@@ -1,42 +1,43 @@
 import * as React from 'react';
-import { IDefaultProps } from '../interfaces';
 
-interface IResizableSidebarProps extends IDefaultProps {
+type ResizableSidebarProps = {
   className?: string;
-  none: boolean;
-  /** If the sidebar should not be visible */
+  /** If the sidebar should not be visible. */
   hide: boolean;
-  /** Where the divider should be located */
+  /** Where the divider should be located (relative to the sidebar). */
   divider: DividerOrientation;
-  /** Width of the whole sidebar */
+  /** Width of the whole sidebar (in pixels). */
   width?: number | string;
-  /** Called when starting to resize the sidebar (when the divider is grabbed) */
+  /** Called when starting to resize the sidebar (when the divider is grabbed). */
   onResizeStart?: () => void;
-  /** Called when the sidebar is resized (when the cursor is moving while the divider is grabbed) */
-  onResize?: (event: IResizeEvent) => void;
-  /** Called when ending the resize the sidebar (when the divider is released) */
+  /** Called when the sidebar is resized (when the cursor is moving while the divider is grabbed). */
+  onResize?: (event: SidebarResizeEvent) => void;
+  /** Called when ending the resize the sidebar (when the divider is released). */
   onResizeEnd?: () => void;
-}
+};
 
-export interface IResizableSidebarState {
-  /** If the divider is grabbed */
+type ResizableSidebarState = {
+  /** If the divider is grabbed. */
   isDragging: boolean;
-  /** Cursors x position when it grabbed the divider */
+  /** The cursor's x position when it grabbed the divider (in pixels). */
   startX: number;
-  /** Width of the whole sidebar when the divider is grabbed */
+  /** Width of the whole sidebar when the divider was grabbed. */
   startWidth: number;
-}
+};
 
-export interface IResizeEvent {
+export type SidebarResizeEvent = {
+  /** Underlying mouse event. */
   event: MouseEvent;
+  /** The cursor's x position when it grabbed the divider (in pixels). */
   startX: number;
+  /** Width of the whole sidebar when the divider was grabbed. */
   startWidth: number;
-}
+};
 
-export class IResizableSidebar extends React.Component<IResizableSidebarProps, IResizableSidebarState> {
-  private sidebarRef: React.RefObject<HTMLDivElement> = React.createRef();
+export class ResizableSidebar extends React.Component<ResizableSidebarProps, ResizableSidebarState> {
+  sidebarRef: React.RefObject<HTMLDivElement> = React.createRef();
   
-  constructor(props: IResizableSidebarProps) {
+  constructor(props: ResizableSidebarProps) {
     super(props);
     this.state = {
       isDragging: false,
@@ -56,14 +57,16 @@ export class IResizableSidebar extends React.Component<IResizableSidebarProps, I
   }
 
   render() {
-    const { none, hide, className, divider, width } = this.props;
+    const { hide, className, divider, width } = this.props;
     return (
-      <div className={'game-browser__sidebar'+
-                      (className?' '+className+' ':'')+
-                      (none?'':' game-browser__sidebar--none')+
-                      (hide?'':' game-browser__sidebar--hidden')}
-            style={{ width }}
-            ref={this.sidebarRef}>
+      <div
+        className={
+          'game-browser__sidebar' +
+          (className ? ' '+className+' ' : '') +
+          (hide ? '' : ' game-browser__sidebar--hidden')
+        }
+        style={{ width }}
+        ref={this.sidebarRef}>
         <div className='game-browser__sidebar__inner'>
           { divider === 'before' && this.renderDivider() }
           <div className='game-browser__sidebar__content simple-scroll'>
@@ -75,7 +78,7 @@ export class IResizableSidebar extends React.Component<IResizableSidebarProps, I
     );
   }
 
-  private renderDivider() {
+  renderDivider() {
     return (
       <div className='game-browser__sidebar__divider'
            onMouseDown={this.onDividerMouseDown}>
@@ -83,7 +86,7 @@ export class IResizableSidebar extends React.Component<IResizableSidebarProps, I
     );
   }
 
-  private onDividerMouseDown = (event: React.MouseEvent): void => {
+  onDividerMouseDown = (event: React.MouseEvent): void => {
     if (event.button === 0 && !this.state.isDragging) {
       if (!document.defaultView) { throw new Error('"document.defaultView" missing.'); }
       if (!this.sidebarRef.current) { throw new Error('sidebar div is missing.'); }
@@ -97,7 +100,7 @@ export class IResizableSidebar extends React.Component<IResizableSidebarProps, I
     }
   }
 
-  private onMouseUp = (event: MouseEvent): void => {
+  onMouseUp = (event: MouseEvent): void => {
     if (event.button === 0 && this.state.isDragging) {
       this.setState({ isDragging: false });
       if (this.props.onResizeEnd) { this.props.onResizeEnd(); }
@@ -105,7 +108,7 @@ export class IResizableSidebar extends React.Component<IResizableSidebarProps, I
     }
   }
 
-  private onMouseMove = (event: MouseEvent): void => {
+  onMouseMove = (event: MouseEvent): void => {
     if (this.state.isDragging) {
       const { startX, startWidth } = this.state;
       if (this.props.onResize) { this.props.onResize({ event, startX, startWidth }); }

--- a/src/renderer/components/RightBrowseSidebar.tsx
+++ b/src/renderer/components/RightBrowseSidebar.tsx
@@ -16,7 +16,7 @@ import { IGamePlaylistEntry } from '../playlist/interfaces';
 import { GamePropSuggestions } from '../util/suggestions';
 import { uuid } from '../uuid';
 import { CheckBox } from './CheckBox';
-import { ConfirmElement, IConfirmElementArgs } from './ConfirmElement';
+import { ConfirmElement, ConfirmElementArgs } from './ConfirmElement';
 import { DropdownInputField } from './DropdownInputField';
 import { GameImageSplit } from './GameImageSplit';
 import { ImagePreview } from './ImagePreview';
@@ -28,7 +28,7 @@ import { IGameLibraryFileItem } from 'src/shared/library/interfaces';
 const copyFile = promisify(fs.copyFile);
 const unlink = promisify(fs.unlink);
 
-interface OwnProps {
+type OwnProps = {
   gameImages: GameImageCollection;
   games: GameManager;
   /** Currently selected game (if any) */
@@ -55,36 +55,36 @@ interface OwnProps {
   onEditClick?: () => void;
   onDiscardClick?: () => void;
   onSaveGame?: () => void;
-}
+};
 
-export type IRightBrowseSidebarProps = OwnProps & WithPreferencesProps;
+export type RightBrowseSidebarProps = OwnProps & WithPreferencesProps;
 
-export interface IRightBrowseSidebarState {
-  /** If a preview of the current games screenshot should be shown */
+type RightBrowseSidebarState = {
+  /** If a preview of the current game's screenshot should be shown. */
   showPreview: boolean;
-}
+};
 
-/** Sidebar on the right side of BrowsePage */
-export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps, IRightBrowseSidebarState> {
-  // Bound "on done" handlers
-  private onTitleChange           = this.wrapOnTextChange((game, text) => { game.title = text; });
-  private onDeveloperChange       = this.wrapOnTextChange((game, text) => { game.developer = text; });
-  private onGenreChange           = this.wrapOnTextChange((game, text) => { game.genre = text; });
-  private onSeriesChange          = this.wrapOnTextChange((game, text) => { game.series = text; });
-  private onSourceChange          = this.wrapOnTextChange((game, text) => { game.source = text; });
-  private onPublisherChange       = this.wrapOnTextChange((game, text) => { game.publisher = text; });
-  private onPlatformChange        = this.wrapOnTextChange((game, text) => { game.platform = text; });
-  private onPlayModeChange        = this.wrapOnTextChange((game, text) => { game.playMode = text; });
-  private onStatusChange          = this.wrapOnTextChange((game, text) => { game.status = text; });
-  private onLaunchCommandChange   = this.wrapOnTextChange((game, text) => { game.launchCommand = text; });
-  private onApplicationPathChange = this.wrapOnTextChange((game, text) => { game.applicationPath = text; });
-  private onNotesChange           = this.wrapOnTextChange((game, text) => { game.notes = text; });
-  private onBrokenChange          = this.wrapOnCheckBoxChange((game) => { game.broken = !game.broken; });
-  private onExtremeChange         = this.wrapOnCheckBoxChange((game) => { game.extreme = !game.extreme; });
+/** Sidebar on the right side of BrowsePage. */
+export class RightBrowseSidebar extends React.Component<RightBrowseSidebarProps, RightBrowseSidebarState> {
+  // Bound "on done" handlers for various input elements
+  onTitleChange           = this.wrapOnTextChange((game, text) => { game.title           = text; });
+  onDeveloperChange       = this.wrapOnTextChange((game, text) => { game.developer       = text; });
+  onGenreChange           = this.wrapOnTextChange((game, text) => { game.genre           = text; });
+  onSeriesChange          = this.wrapOnTextChange((game, text) => { game.series          = text; });
+  onSourceChange          = this.wrapOnTextChange((game, text) => { game.source          = text; });
+  onPublisherChange       = this.wrapOnTextChange((game, text) => { game.publisher       = text; });
+  onPlatformChange        = this.wrapOnTextChange((game, text) => { game.platform        = text; });
+  onPlayModeChange        = this.wrapOnTextChange((game, text) => { game.playMode        = text; });
+  onStatusChange          = this.wrapOnTextChange((game, text) => { game.status          = text; });
+  onLaunchCommandChange   = this.wrapOnTextChange((game, text) => { game.launchCommand   = text; });
+  onApplicationPathChange = this.wrapOnTextChange((game, text) => { game.applicationPath = text; });
+  onNotesChange           = this.wrapOnTextChange((game, text) => { game.notes           = text; });
+  onBrokenChange          = this.wrapOnCheckBoxChange(game => { game.broken  = !game.broken;  });
+  onExtremeChange         = this.wrapOnCheckBoxChange(game => { game.extreme = !game.extreme; });
 
-  private launchCommandRef: React.RefObject<HTMLInputElement> = React.createRef();
+  launchCommandRef: React.RefObject<HTMLInputElement> = React.createRef();
 
-  constructor(props: IRightBrowseSidebarProps) {
+  constructor(props: RightBrowseSidebarProps) {
     super(props);
     this.state = {
       showPreview: false,
@@ -100,7 +100,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
   }
 
   render() {
-    const game: IGameInfo|undefined = this.props.currentGame;
+    const game: IGameInfo | undefined = this.props.currentGame;
     if (game) {
       const { currentAddApps, gameImages, gamePlaylistEntry, isEditing, isNewGame, preferencesData, suggestions } = this.props;
       const isPlaceholder = game.placeholder;
@@ -111,16 +111,19 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
       const screenshotSrc = gameImages.getScreenshotPath(game);
       const thumbnailSrc = gameImages.getThumbnailPath(game);
       return (
-        <div className={'browse-right-sidebar '+
-                        (canEdit ? 'browse-right-sidebar--edit-enabled' : 'browse-right-sidebar--edit-disabled')}
-             onKeyDown={this.onLocalKeyDown}>
+        <div
+          className={'browse-right-sidebar ' + (canEdit ? 'browse-right-sidebar--edit-enabled' : 'browse-right-sidebar--edit-disabled')}
+          onKeyDown={this.onLocalKeyDown}>
           {/* -- Title & Developer(s) -- */}
           <div className='browse-right-sidebar__section'>
             <div className='browse-right-sidebar__row'>
               <div className='browse-right-sidebar__title-row'>
                 <div className='browse-right-sidebar__title-row__title'>
-                  <InputField text={game.title} placeholder='No Title'
-                              onChange={this.onTitleChange} canEdit={canEdit} />
+                  <InputField
+                    text={game.title}
+                    placeholder='No Title'
+                    onChange={this.onTitleChange}
+                    canEdit={canEdit} />
                 </div>
                 <div className='browse-right-sidebar__title-row__buttons'>
                   { editDisabled ? undefined : (
@@ -128,13 +131,17 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
                       { isEditing ? ( /* While Editing */
                         <>
                           {/* "Save" Button */}
-                          <div className='browse-right-sidebar__title-row__buttons__save-button'
-                              title='Save Changes' onClick={this.props.onSaveGame}>
+                          <div
+                            className='browse-right-sidebar__title-row__buttons__save-button'
+                            title='Save Changes'
+                            onClick={this.props.onSaveGame}>
                             <OpenIcon icon='check' />
                           </div>
                           {/* "Discard" Button */}
-                          <div className='browse-right-sidebar__title-row__buttons__discard-button'
-                              title='Discard Changes' onClick={this.props.onDiscardClick}>
+                          <div
+                            className='browse-right-sidebar__title-row__buttons__discard-button'
+                            title='Discard Changes'
+                            onClick={this.props.onDiscardClick}>
                             <OpenIcon icon='x' />
                           </div>
                         </>
@@ -142,20 +149,24 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
                         <>
                           {/* "Edit" Button */}
                           { isPlaceholder ? undefined : (
-                            <div className='browse-right-sidebar__title-row__buttons__edit-button'
-                                 title='Edit Game' onClick={this.props.onEditClick}>
+                            <div
+                              className='browse-right-sidebar__title-row__buttons__edit-button'
+                              title='Edit Game'
+                              onClick={this.props.onEditClick}>
                               <OpenIcon icon='pencil' />
                             </div>
                           ) }
                           {/* "Remove From Playlist" Button */}
                           { gamePlaylistEntry ? (
-                            <ConfirmElement onConfirm={this.props.onRemoveSelectedGameFromPlaylist}
-                                            children={this.renderRemoveFromPlaylistButton} />
+                            <ConfirmElement
+                              onConfirm={this.props.onRemoveSelectedGameFromPlaylist}
+                              children={this.renderRemoveFromPlaylistButton} />
                           ) : undefined }
                           {/* "Delete Game" Button */}
                           { (isPlaceholder || isNewGame || gamePlaylistEntry) ? undefined : (
-                            <ConfirmElement onConfirm={this.onDeleteGameClick}
-                                            children={this.renderDeleteGameButton} />
+                            <ConfirmElement
+                              onConfirm={this.onDeleteGameClick}
+                              children={this.renderDeleteGameButton} />
                           ) }
                         </>
                       ) }
@@ -167,8 +178,12 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
             { isPlaceholder ? undefined : (
               <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                 <p>by </p>
-                <InputField text={game.developer} placeholder='No Developer'
-                            onChange={this.onDeveloperChange} canEdit={canEdit} onKeyDown={this.onInputKeyDown} />
+                <InputField
+                  text={game.developer}
+                  placeholder='No Developer'
+                  onChange={this.onDeveloperChange}
+                  canEdit={canEdit}
+                  onKeyDown={this.onInputKeyDown} />
               </div>
             ) }
           </div>
@@ -178,65 +193,99 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
               <div className='browse-right-sidebar__section'>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Genre: </p>
-                  <DropdownInputField text={game.genre} placeholder='No Genre'
-                                      onChange={this.onGenreChange} canEdit={canEdit}
-                                      items={suggestions && filterSuggestions(suggestions.genre) || []}
-                                      onItemSelect={text => { game.genre = text; this.forceUpdate(); }}
-                                      onKeyDown={this.onInputKeyDown} />
+                  <DropdownInputField
+                    text={game.genre}
+                    placeholder='No Genre'
+                    onChange={this.onGenreChange}
+                    canEdit={canEdit}
+                    items={suggestions && filterSuggestions(suggestions.genre) || []}
+                    onItemSelect={text => { game.genre = text; this.forceUpdate(); }}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Series: </p>
-                  <InputField text={game.series} placeholder='No Series'
-                              onChange={this.onSeriesChange} canEdit={canEdit} onKeyDown={this.onInputKeyDown} />
+                  <InputField
+                    text={game.series}
+                    placeholder='No Series'
+                    onChange={this.onSeriesChange}
+                    canEdit={canEdit}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Publisher: </p>
-                  <InputField text={game.publisher} placeholder='No Publisher'
-                              onChange={this.onPublisherChange} canEdit={canEdit} onKeyDown={this.onInputKeyDown} />
+                  <InputField
+                    text={game.publisher}
+                    placeholder='No Publisher'
+                    onChange={this.onPublisherChange}
+                    canEdit={canEdit}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Source: </p>
-                  <InputField text={game.source} placeholder='No Source'
-                              onChange={this.onSourceChange} canEdit={canEdit} onKeyDown={this.onInputKeyDown} />
+                  <InputField
+                    text={game.source}
+                    placeholder='No Source'
+                    onChange={this.onSourceChange}
+                    canEdit={canEdit}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Platform: </p>
-                  <DropdownInputField text={game.platform} placeholder='No Platform'
-                                      onChange={this.onPlatformChange} canEdit={canEdit}
-                                      items={suggestions && filterSuggestions(suggestions.platform) || []}
-                                      onItemSelect={text => { game.platform = text; this.forceUpdate(); }}
-                                      onKeyDown={this.onInputKeyDown} />
+                  <DropdownInputField
+                    text={game.platform}
+                    placeholder='No Platform'
+                    onChange={this.onPlatformChange}
+                    canEdit={canEdit}
+                    items={suggestions && filterSuggestions(suggestions.platform) || []}
+                    onItemSelect={text => { game.platform = text; this.forceUpdate(); }}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Play Mode: </p>
-                  <DropdownInputField text={game.playMode} placeholder='No Play Mode'
-                                      onChange={this.onPlayModeChange} canEdit={canEdit}
-                                      items={suggestions && filterSuggestions(suggestions.playMode) || []}
-                                      onItemSelect={text => { game.playMode = text; this.forceUpdate(); }}
-                                      onKeyDown={this.onInputKeyDown} />
+                  <DropdownInputField
+                    text={game.playMode}
+                    placeholder='No Play Mode'
+                    onChange={this.onPlayModeChange}
+                    canEdit={canEdit}
+                    items={suggestions && filterSuggestions(suggestions.playMode) || []}
+                    onItemSelect={text => { game.playMode = text; this.forceUpdate(); }}
+                    onKeyDown={this.onInputKeyDown} />
 
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Status: </p>
-                  <DropdownInputField text={game.status} placeholder='No Status'
-                                      onChange={this.onStatusChange} canEdit={canEdit}
-                                      items={suggestions && filterSuggestions(suggestions.status) || []}
-                                      onItemSelect={text => { game.status = text; this.forceUpdate(); }}
-                                      onKeyDown={this.onInputKeyDown} />
+                  <DropdownInputField
+                    text={game.status}
+                    placeholder='No Status'
+                    onChange={this.onStatusChange}
+                    canEdit={canEdit}
+                    items={suggestions && filterSuggestions(suggestions.status) || []}
+                    onItemSelect={text => { game.status = text; this.forceUpdate(); }}
+                    onKeyDown={this.onInputKeyDown} />
                 </div>
                 <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                   <p>Date Added: </p>
-                  <p className='browse-right-sidebar__row__date-added' title={dateAdded}>{dateAdded}</p>
+                  <p
+                    className='browse-right-sidebar__row__date-added'
+                    title={dateAdded}>{dateAdded}</p>
                 </div>
                 <div className='browse-right-sidebar__row'>
-                  <div className='browse-right-sidebar__row__check-box-wrapper' onClick={this.onBrokenChange}>
-                    <CheckBox checked={game.broken} className='browse-right-sidebar__row__check-box' />
+                  <div
+                    className='browse-right-sidebar__row__check-box-wrapper'
+                    onClick={this.onBrokenChange}>
+                    <CheckBox
+                      checked={game.broken}
+                      className='browse-right-sidebar__row__check-box' />
                     <p> Broken (in Infinity)</p>
                   </div>
                 </div>
                 <div className='browse-right-sidebar__row'>
-                  <div className='browse-right-sidebar__row__check-box-wrapper' onClick={this.onExtremeChange}>
-                    <CheckBox checked={game.extreme} className='browse-right-sidebar__row__check-box' />
+                  <div
+                    className='browse-right-sidebar__row__check-box-wrapper'
+                    onClick={this.onExtremeChange}>
+                    <CheckBox
+                      checked={game.extreme}
+                      className='browse-right-sidebar__row__check-box' />
                     <p> Extreme</p>                
                   </div>
                 </div>
@@ -248,8 +297,12 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
             <div className='browse-right-sidebar__section'>
               <div className='browse-right-sidebar__row'>
                 <p>Playlist Notes: </p>
-                <InputField text={gamePlaylistEntry.notes || ''} placeholder='No Playlist Notes'
-                            onChange={this.onEditPlaylistNotes} canEdit={canEdit} multiline={true} />
+                <InputField
+                  text={gamePlaylistEntry.notes || ''}
+                  placeholder='No Playlist Notes'
+                  onChange={this.onEditPlaylistNotes}
+                  canEdit={canEdit}
+                  multiline={true} />
               </div>
             </div>
           ) : undefined }
@@ -258,8 +311,12 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
             <div className='browse-right-sidebar__section'>
               <div className='browse-right-sidebar__row'>
                 <p>Notes: </p>
-                <InputField text={game.notes} placeholder='No Notes'
-                            onChange={this.onNotesChange} canEdit={canEdit} multiline={true} />
+                <InputField
+                  text={game.notes}
+                  placeholder='No Notes'
+                  onChange={this.onNotesChange}
+                  canEdit={canEdit}
+                  multiline={true} />
               </div>
             </div>
           ) : undefined }
@@ -269,14 +326,21 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
               <div className='browse-right-sidebar__row browse-right-sidebar__row--additional-applications-header'>
                 <p>Additional Applications:</p>
                 { canEdit ? (
-                  <input type='button' value='New' className='simple-button' onClick={this.onNewAddAppClick} />
+                  <input
+                    type='button'
+                    value='New'
+                    className='simple-button'
+                    onClick={this.onNewAddAppClick} />
                 ) : undefined }
               </div>
-              { currentAddApps && currentAddApps.map((addApp) => {
-                return <RightBrowseSidebarAddApp key={addApp.id} addApp={addApp} editDisabled={!canEdit}
-                                                 onLaunch={this.onAddAppLaunch}
-                                                 onDelete={this.onAddAppDelete} />;
-              }) }
+              { currentAddApps && currentAddApps.map((addApp) => (
+                <RightBrowseSidebarAddApp
+                  key={addApp.id}
+                  addApp={addApp}
+                  editDisabled={!canEdit}
+                  onLaunch={this.onAddAppLaunch}
+                  onDelete={this.onAddAppDelete} />
+              )) }
             </div>
           ) : undefined }
           {/* -- Application Path & Launch Command -- */}
@@ -284,17 +348,24 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
             <div className='browse-right-sidebar__section'>
               <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                 <p>Application Path: </p>
-                <DropdownInputField text={game.applicationPath} placeholder='No Application Path'
-                                    onChange={this.onApplicationPathChange} canEdit={canEdit}
-                                    items={suggestions && filterSuggestions(suggestions.applicationPath) || []}
-                                    onItemSelect={text => { game.applicationPath = text; this.forceUpdate(); }}
-                                    onKeyDown={this.onInputKeyDown} />
+                <DropdownInputField
+                  text={game.applicationPath}
+                  placeholder='No Application Path'
+                  onChange={this.onApplicationPathChange}
+                  canEdit={canEdit}
+                  items={suggestions && filterSuggestions(suggestions.applicationPath) || []}
+                  onItemSelect={text => { game.applicationPath = text; this.forceUpdate(); }}
+                  onKeyDown={this.onInputKeyDown} />
               </div>
               <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
                 <p>Launch Command: </p>
-                <InputField text={game.launchCommand} placeholder='No Launch Command'
-                            onChange={this.onLaunchCommandChange} canEdit={canEdit} onKeyDown={this.onInputKeyDown}
-                            reference={this.launchCommandRef} />
+                <InputField
+                  text={game.launchCommand}
+                  placeholder='No Launch Command'
+                  onChange={this.onLaunchCommandChange}
+                  canEdit={canEdit}
+                  onKeyDown={this.onInputKeyDown}
+                  reference={this.launchCommandRef} />
               </div>
             </div>
           ) : undefined }
@@ -316,30 +387,38 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
                 { isEditing ? (
                   <div className='browse-right-sidebar__row__screenshot__placeholder'>
                     <div className='browse-right-sidebar__row__screenshot__placeholder__back'>
-                      <GameImageSplit text='Thumbnail' imgSrc={thumbnailSrc}
-                                      onAddClick={this.addThumbnailDialog}
-                                      onRemoveClick={this.onRemoveThumbnailClick}
-                                      onDrop={this.onImageDrop}
-                                      disabled={!imageFolderName}/>
-                      <GameImageSplit text='Screenshot' imgSrc={screenshotSrc}
-                                      onAddClick={this.addScreenshotDialog}
-                                      onRemoveClick={this.onRemoveScreenshotClick}
-                                      onDrop={this.onImageDrop}
-                                      disabled={!imageFolderName}/>
+                      <GameImageSplit
+                        text='Thumbnail'
+                        imgSrc={thumbnailSrc}
+                        onAddClick={this.addThumbnailDialog}
+                        onRemoveClick={this.onRemoveThumbnailClick}
+                        onDrop={this.onImageDrop}
+                        disabled={!imageFolderName} />
+                      <GameImageSplit
+                        text='Screenshot'
+                        imgSrc={screenshotSrc}
+                        onAddClick={this.addScreenshotDialog}
+                        onRemoveClick={this.onRemoveScreenshotClick}
+                        onDrop={this.onImageDrop}
+                        disabled={!imageFolderName} />
                     </div>
                     <div className='browse-right-sidebar__row__screenshot__placeholder__front'>
                       <p>Drop an image here to add it.</p>
                     </div>
                   </div>
                 ) : (
-                  <img src={screenshotSrc} onClick={this.onScreenshotClick} />
+                  <img
+                    src={screenshotSrc}
+                    onClick={this.onScreenshotClick} />
                 ) }
               </div>
             </div>
           </div>
           {/* -- Screenshot Preview -- */}
           { this.state.showPreview ? (
-            <ImagePreview src={screenshotSrc} onCancel={this.onScreenshotPreviewClick} />
+            <ImagePreview
+              src={screenshotSrc}
+              onCancel={this.onScreenshotPreviewClick} />
           ) : undefined }
         </div>
       );
@@ -353,30 +432,38 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  private renderDeleteGameButton({ activate, activationCounter, reset }: IConfirmElementArgs): JSX.Element {
+  renderDeleteGameButton({ activate, activationCounter, reset }: ConfirmElementArgs): JSX.Element {
     return (
-      <div className={'browse-right-sidebar__title-row__buttons__delete-game'+
-                      ((activationCounter>0)?' browse-right-sidebar__title-row__buttons__delete-game--active simple-vertical-shake':'')}
-           title='Delete Game (and Additional Applications)'
-           onClick={activate} onMouseLeave={reset}>
+      <div
+        className={
+          'browse-right-sidebar__title-row__buttons__delete-game' +
+          ((activationCounter > 0) ? ' browse-right-sidebar__title-row__buttons__delete-game--active simple-vertical-shake' : '')
+        }
+        title='Delete Game (and Additional Applications)'
+        onClick={activate}
+        onMouseLeave={reset}>
         <OpenIcon icon='trash' />
       </div>
     );
   }
 
-  private renderRemoveFromPlaylistButton({ activate, activationCounter, reset }: IConfirmElementArgs): JSX.Element {
+  renderRemoveFromPlaylistButton({ activate, activationCounter, reset }: ConfirmElementArgs): JSX.Element {
     return (
-      <div className={'browse-right-sidebar__title-row__buttons__remove-from-playlist'+
-                      ((activationCounter>0)?' browse-right-sidebar__title-row__buttons__remove-from-playlist--active simple-vertical-shake':'')}
-           title='Remove Game from Playlist'
-           onClick={activate} onMouseLeave={reset}>
+      <div
+        className={
+          'browse-right-sidebar__title-row__buttons__remove-from-playlist' +
+          ((activationCounter > 0) ? ' browse-right-sidebar__title-row__buttons__remove-from-playlist--active simple-vertical-shake' : '')
+        }
+        title='Remove Game from Playlist'
+        onClick={activate}
+        onMouseLeave={reset}>
         <OpenIcon icon='circle-x' />
       </div>
     );
   }
 
   /** When a key is pressed down "globally" (and this component is present) */
-  private onGlobalKeyDown = (event: KeyboardEvent) => {
+  onGlobalKeyDown = (event: KeyboardEvent) => {
     const { currentGame, isEditing, onEditClick } = this.props;
     // Start editing
     if (event.ctrlKey && event.code === 'KeyE' && // (CTRL + E ...
@@ -387,7 +474,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
   
-  private onLocalKeyDown = (event: React.KeyboardEvent) => {
+  onLocalKeyDown = (event: React.KeyboardEvent) => {
     const { currentGame, isEditing, onSaveGame } = this.props;
     // Save changes
     if (event.ctrlKey && event.key === 's' && // (CTRL + S ...
@@ -397,7 +484,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
   
-  private onScreenshotContextMenu = (event: React.MouseEvent) => {
+  onScreenshotContextMenu = (event: React.MouseEvent) => {
     const { currentGame, gameImages } = this.props;
     const template: MenuItemConstructorOptions[] = [];
     if (currentGame) {
@@ -426,14 +513,14 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  private deleteImage(cache: ImageFolderCache|undefined): void {
+  deleteImage(cache: ImageFolderCache|undefined): void {
     const { currentGame } = this.props;
     if (!currentGame) { throw new Error('Failed to delete image file. The currently selected game could not be found.'); }
     if (!cache)       { throw new Error('Failed to delete image file. The image cache could not be found.'); }
     deleteImageFiles(currentGame, cache).then(() => { this.forceUpdate(); });
   }
 
-  private addScreenshotDialog = async () => {
+  addScreenshotDialog = async () => {
     const { currentGame, gameImages } = this.props;
       if (!currentGame) { throw new Error('Failed to add image file. The currently selected game could not be found.'); }
     // Synchronously show a "open dialog" (this makes the main window "frozen" while this is open)
@@ -454,7 +541,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  private addThumbnailDialog = async () => {
+  addThumbnailDialog = async () => {
     const { currentGame, gameImages } = this.props;
       if (!currentGame) { throw new Error('Failed to add image file. The currently selected game could not be found.'); }
     // Synchronously show a "open dialog" (this makes the main window "frozen" while this is open)
@@ -475,15 +562,15 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
   
-  private onRemoveScreenshotClick = (): void => {
+  onRemoveScreenshotClick = (): void => {
     this.deleteImage(this.props.gameImages.getScreenshotCache(this.getImageFolderName()));
   }
   
-  private onRemoveThumbnailClick = (): void => {
+  onRemoveThumbnailClick = (): void => {
     this.deleteImage(this.props.gameImages.getThumbnailCache(this.getImageFolderName()));
   }
 
-  private onImageDrop = (event: React.DragEvent, text: string): void => {
+  onImageDrop = (event: React.DragEvent, text: string): void => {
     event.preventDefault();
     const files = copyArrayLike(event.dataTransfer.files);
     const game = this.props.currentGame;
@@ -511,7 +598,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  private onDeleteGameClick = (): void => {
+  onDeleteGameClick = (): void => {
     console.time('delete');
     const game = this.props.currentGame;
     if (!game) { throw new Error('Can not delete a game when no game is selected.'); }
@@ -531,11 +618,11 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  private onAddAppLaunch(addApp: IAdditionalApplicationInfo): void {
+  onAddAppLaunch(addApp: IAdditionalApplicationInfo): void {
     GameLauncher.launchAdditionalApplication(addApp);
   }
 
-  private onAddAppDelete = (addApp: IAdditionalApplicationInfo): void => {
+  onAddAppDelete = (addApp: IAdditionalApplicationInfo): void => {
     const addApps = this.props.currentAddApps;
     if (!addApps) { throw new Error('editAddApps is missing.'); }
     // Find and remove add-app
@@ -551,7 +638,7 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     this.forceUpdate();
   }
 
-  private onNewAddAppClick = (): void => {
+  onNewAddAppClick = (): void => {
     if (!this.props.currentAddApps) { throw new Error(`Unable to add a new AddApp. "currentAddApps" is missing.`); }
     if (!this.props.currentGame)    { throw new Error(`Unable to add a new AddApp. "currentGame" is missing.`); }
     const newAddApp = AdditionalApplicationInfo.create();
@@ -561,15 +648,15 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     this.forceUpdate();
   }
 
-  private onScreenshotClick = (): void => {
+  onScreenshotClick = (): void => {
     this.setState({ showPreview: true });
   }
 
-  private onScreenshotPreviewClick = (): void => {
+  onScreenshotPreviewClick = (): void => {
     this.setState({ showPreview: false });
   }
 
-  private onEditPlaylistNotes = (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>): void => {
+  onEditPlaylistNotes = (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>): void => {
     if (this.props.onEditPlaylistNotes) {
       this.props.onEditPlaylistNotes(event.currentTarget.value);
       this.forceUpdate();
@@ -577,14 +664,14 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
   }
 
   /** When a key is pressed while an input field is selected (except for multiline fields) */
-  private onInputKeyDown = (event: React.KeyboardEvent): void => {
+  onInputKeyDown = (event: React.KeyboardEvent): void => {
     if (event.key === 'Enter') {
       if (this.props.onSaveGame) { this.props.onSaveGame(); }
     }
   }
 
-  /** Create a wrapper for a EditableTextWrap's onChange callback (this is to reduce redundancy) */
-  private wrapOnTextChange(func: (game: IGameInfo, text: string) => void): (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => void {
+  /** Create a wrapper for a EditableTextWrap's onChange callback (this is to reduce redundancy). */
+  wrapOnTextChange(func: (game: IGameInfo, text: string) => void): (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => void {
     return (event) => {
       const game = this.props.currentGame;
       if (game) {
@@ -594,8 +681,8 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  /** Create a wrapper for a CheckBox's onChange callback (this is to reduce redundancy) */
-  private wrapOnCheckBoxChange(func: (game: IGameInfo) => void): () => void {
+  /** Create a wrapper for a CheckBox's onChange callback (this is to reduce redundancy). */
+  wrapOnCheckBoxChange(func: (game: IGameInfo) => void): () => void {
     return () => {
       const game = this.props.currentGame;
       const canEdit = this.props.preferencesData.enableEditing && this.props.isEditing;
@@ -606,8 +693,8 @@ export class RightBrowseSidebar extends React.Component<IRightBrowseSidebarProps
     }
   }
 
-  /** Get the image folder name of the current game */
-  private getImageFolderName(): string {
+  /** Get the name of the image folder for the current game. */
+  getImageFolderName(): string {
     const { currentGame, currentLibrary, isNewGame } = this.props;
     const prefix = (currentLibrary && currentLibrary.prefix) ? currentLibrary.prefix : '';
     if (currentGame) {
@@ -625,6 +712,7 @@ function filterSuggestions(suggestions?: string[]): string[] {
   return suggestions;
 }
 
+/** Open a context menu, built from the specified template. */
 function openContextMenu(template: MenuItemConstructorOptions[]): Menu {
   const menu = remote.Menu.buildFromTemplate(template);
   menu.popup({ window: remote.getCurrentWindow() });
@@ -632,14 +720,15 @@ function openContextMenu(template: MenuItemConstructorOptions[]): Menu {
 }
 
 /**
- * Copy an image file from anywhere to the folder of an "image cache" and for a specific game
- * @param source File path of the image to copy
- * @param game Game that the image will "belong" to
- * @param cache Image cache to store the image in (it is copied to this caches folder)
+ * Copy an image file from anywhere to the folder of an "image cache" and for a specific game.
+ * @param source File path of the image to copy.
+ * @param game Game that the image will "belong" to.
+ * @param cache Image cache to store the image in (it is copied to this caches folder).
  */
 async function copyImageFile(source: string, game: IGameInfo, cache: ImageFolderCache): Promise<void> {
+  // Delete the current image(s)
   deleteImageFiles(game, cache);
-  // Copy the image to index 1
+  // Copy image file (and give it index 1, since only one screenshot per game is supported at the moment)
   const outputPath = path.join(
     cache.getFolderPath(),
     formatImageFilename(game.id, 1) + getFileExtension(source)
@@ -656,6 +745,11 @@ function getFileExtension(filename: string): string {
   return filename.substr(firstDot);
 }
 
+/**
+ * Create a new array and populate it with the properties and values from another array or array like object.
+ * @param arrayLike Array or array like object to copy properties and values from.
+ * @returns New array with the same properties and values as the argument.
+ */
 function copyArrayLike<T>(arrayLike: { [key: number]: T }): Array<T> {
   const array: T[] = [];
   for (let key in arrayLike) {
@@ -665,9 +759,9 @@ function copyArrayLike<T>(arrayLike: { [key: number]: T }): Array<T> {
 }
 
 /**
- * Delete all images of the given game in the given cache
- * @param game Game to delete images of
- * @param cache Cache to delete image from
+ * Delete all image files of a game in the specified cache.
+ * @param game The game to delete all the image files of.
+ * @param cache Cache of the image folder to delete the files from.
  */
 async function deleteImageFiles(game: IGameInfo, cache: ImageFolderCache): Promise<void> {
   // Find and delete all of the games images in the cache

--- a/src/renderer/components/RightBrowseSidebarAddApp.tsx
+++ b/src/renderer/components/RightBrowseSidebarAddApp.tsx
@@ -19,7 +19,7 @@ export type RightBrowseSidebarAddAppProps = {
 };
 
 /** Displays an additional application for a game in the right sidebar of BrowsePage. */
-export class RightBrowseSidebarAddApp extends React.Component<RightBrowseSidebarAddAppProps, {}> {
+export class RightBrowseSidebarAddApp extends React.Component<RightBrowseSidebarAddAppProps> {
   onNameEditDone            = this.wrapOnTextChange((addApp, text) => { addApp.name = text; });
   onApplicationPathEditDone = this.wrapOnTextChange((addApp, text) => { addApp.applicationPath = text; });
   onCommandLineEditDone     = this.wrapOnTextChange((addApp, text) => { addApp.commandLine = text; });

--- a/src/renderer/components/RightBrowseSidebarAddApp.tsx
+++ b/src/renderer/components/RightBrowseSidebarAddApp.tsx
@@ -3,9 +3,9 @@ import { IAdditionalApplicationInfo } from '../../shared/game/interfaces';
 import { CheckBox } from './CheckBox';
 import { InputField } from './InputField';
 import { OpenIcon } from './OpenIcon';
-import { ConfirmElement, IConfirmElementArgs } from './ConfirmElement';
+import { ConfirmElement, ConfirmElementArgs } from './ConfirmElement';
 
-export interface IRightBrowseSidebarAddAppProps {
+export type RightBrowseSidebarAddAppProps = {
   /** Additional Application to show and edit */
   addApp: IAdditionalApplicationInfo;
   /** Called when a field is edited */
@@ -16,18 +16,15 @@ export interface IRightBrowseSidebarAddAppProps {
   onLaunch?: (addApp: IAdditionalApplicationInfo) => void;
   /** If the editing is disabled (it cant go into "edit mode") */
   editDisabled?: boolean;
-}
+};
 
-export class RightBrowseSidebarAddApp extends React.Component<IRightBrowseSidebarAddAppProps, {}> {
-  private onNameEditDone            = this.wrapOnTextChange((addApp, text) => { addApp.name = text; });
-  private onApplicationPathEditDone = this.wrapOnTextChange((addApp, text) => { addApp.applicationPath = text; });
-  private onCommandLineEditDone     = this.wrapOnTextChange((addApp, text) => { addApp.commandLine = text; });
-  private onAutoRunBeforeChange     = this.wrapOnCheckBoxChange((addApp) => { addApp.autoRunBefore = !addApp.autoRunBefore; });
-  private onWaitForExitChange       = this.wrapOnCheckBoxChange((addApp) => { addApp.waitForExit = !addApp.waitForExit; });
-
-  constructor(props: IRightBrowseSidebarAddAppProps) {
-    super(props);
-  }
+/** Displays an additional application for a game in the right sidebar of BrowsePage. */
+export class RightBrowseSidebarAddApp extends React.Component<RightBrowseSidebarAddAppProps, {}> {
+  onNameEditDone            = this.wrapOnTextChange((addApp, text) => { addApp.name = text; });
+  onApplicationPathEditDone = this.wrapOnTextChange((addApp, text) => { addApp.applicationPath = text; });
+  onCommandLineEditDone     = this.wrapOnTextChange((addApp, text) => { addApp.commandLine = text; });
+  onAutoRunBeforeChange     = this.wrapOnCheckBoxChange((addApp) => { addApp.autoRunBefore = !addApp.autoRunBefore; });
+  onWaitForExitChange       = this.wrapOnCheckBoxChange((addApp) => { addApp.waitForExit = !addApp.waitForExit; });
 
   render() {
     const { addApp, editDisabled } = this.props;
@@ -35,41 +32,63 @@ export class RightBrowseSidebarAddApp extends React.Component<IRightBrowseSideba
       <div className='browse-right-sidebar__additional-application'>
         {/* Title & Launch Button */}
         <div className='browse-right-sidebar__row browse-right-sidebar__row--additional-applications-name'>
-          <InputField text={addApp.name} placeholder='No Name'
-                      onChange={this.onNameEditDone} canEdit={!editDisabled} />
-          <input type="button" className="simple-button" value="Launch" onClick={this.onLaunchClick}/>
+          <InputField
+            text={addApp.name}
+            placeholder='No Name'
+            onChange={this.onNameEditDone}
+            canEdit={!editDisabled} />
+          <input
+            type='button'
+            className='simple-button'
+            value='Launch'
+            onClick={this.onLaunchClick}/>
         </div>
         { editDisabled ? undefined : (
           <>
             {/* Application Path */}
             <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
               <p>Application Path: </p>
-              <InputField text={addApp.applicationPath} placeholder='No Application Path'
-                          onChange={this.onApplicationPathEditDone} canEdit={!editDisabled} />
+              <InputField
+                text={addApp.applicationPath}
+                placeholder='No Application Path'
+                onChange={this.onApplicationPathEditDone}
+                canEdit={!editDisabled} />
             </div>
             {/* Command Line */}
             <div className='browse-right-sidebar__row browse-right-sidebar__row--one-line'>
               <p>Command Line: </p>
-              <InputField text={addApp.commandLine} placeholder='No Command Line'
-                          onChange={this.onCommandLineEditDone} canEdit={!editDisabled} />
+              <InputField
+                text={addApp.commandLine}
+                placeholder='No Command Line'
+                onChange={this.onCommandLineEditDone}
+                canEdit={!editDisabled} />
             </div>
             {/* Auto Run Before */}
             <div className='browse-right-sidebar__row'>
-              <div className='browse-right-sidebar__row__check-box-wrapper' onClick={this.onAutoRunBeforeChange}>
-                <CheckBox className='browse-right-sidebar__row__check-box' checked={addApp.autoRunBefore} />
+              <div
+                className='browse-right-sidebar__row__check-box-wrapper'
+                onClick={this.onAutoRunBeforeChange}>
+                <CheckBox
+                  className='browse-right-sidebar__row__check-box'
+                  checked={addApp.autoRunBefore} />
                 <p> Auto Run Before</p>
               </div>
             </div>
             {/* Wait for Exit */}
             <div className='browse-right-sidebar__row'>
-              <div className='browse-right-sidebar__row__check-box-wrapper' onClick={this.onWaitForExitChange}>
-                <CheckBox className='browse-right-sidebar__row__check-box' checked={addApp.waitForExit} />
+              <div
+                className='browse-right-sidebar__row__check-box-wrapper'
+                onClick={this.onWaitForExitChange}>
+                <CheckBox
+                  className='browse-right-sidebar__row__check-box'
+                  checked={addApp.waitForExit} />
                 <p> Wait for Exit</p>
               </div>
               {/* Delete Button */}
               { !editDisabled ? (
-                <ConfirmElement onConfirm={this.onDeleteClick}
-                                children={this.renderDeleteButton} />
+                <ConfirmElement
+                  onConfirm={this.onDeleteClick}
+                  children={this.renderDeleteButton} />
               ) : undefined}
             </div>
           </>
@@ -78,37 +97,39 @@ export class RightBrowseSidebarAddApp extends React.Component<IRightBrowseSideba
     );
   }
 
-  private renderDeleteButton({ activate, activationCounter, reset }: IConfirmElementArgs): JSX.Element {
+  renderDeleteButton({ activate, activationCounter, reset }: ConfirmElementArgs): JSX.Element {
     const className = 'browse-right-sidebar__additional-application__delete-button';
     return (
-      <div className={className + ((activationCounter > 0) ? ` ${className}--active simple-vertical-shake` : '')}
-           title='Delete Additional Application'
-           onClick={activate} onMouseLeave={reset}>
+      <div
+        className={className + ((activationCounter > 0) ? ` ${className}--active simple-vertical-shake` : '')}
+        title='Delete Additional Application'
+        onClick={activate}
+        onMouseLeave={reset}>
         <OpenIcon icon='trash' />
       </div>
     );
   }
 
-  private onLaunchClick = (): void => {
+  onLaunchClick = (): void => {
     if (this.props.onLaunch) {
       this.props.onLaunch(this.props.addApp);
     }
   }
 
-  private onDeleteClick = (): void => {
+  onDeleteClick = (): void => {
     if (this.props.onDelete) {
       this.props.onDelete(this.props.addApp);
     }
   }
 
-  private onEdit(): void {
+  onEdit(): void {
     if (this.props.onEdit) {
       this.props.onEdit();
     }
   }
 
-  /** Create a wrapper for a EditableTextWrap's onEditDone callback (this is to reduce redundancy) */
-  private wrapOnTextChange(func: (addApp: IAdditionalApplicationInfo, text: string) => void): (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => void {
+  /** Create a wrapper for a EditableTextWrap's onEditDone callback (this is to reduce redundancy). */
+  wrapOnTextChange(func: (addApp: IAdditionalApplicationInfo, text: string) => void): (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>) => void {
     return (event) => {
       const addApp = this.props.addApp;
       if (addApp) {
@@ -118,8 +139,8 @@ export class RightBrowseSidebarAddApp extends React.Component<IRightBrowseSideba
     }
   }
 
-  /** Create a wrapper for a CheckBox's onChange callback (this is to reduce redundancy) */
-  private wrapOnCheckBoxChange(func: (addApp: IAdditionalApplicationInfo) => void) {
+  /** Create a wrapper for a CheckBox's onChange callback (this is to reduce redundancy). */
+  wrapOnCheckBoxChange(func: (addApp: IAdditionalApplicationInfo) => void) {
     return () => {
       if (!this.props.editDisabled) {
         func(this.props.addApp);

--- a/src/renderer/components/SimpleButton.tsx
+++ b/src/renderer/components/SimpleButton.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { Omit } from '../../shared/interfaces';
 
-type a = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
-export type SimpleButtonProps = Omit<a, 'type'>;
+/** Props for an input element. */
+type InputProps = React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
 
-export class SimpleButton extends React.PureComponent<SimpleButtonProps> {
-  render() {
-    const { className, ...rest } = this.props;
-    return (
-      <input type='button'
-             className={'simple-button' + (className ? ' '+className : '') }
-             { ...rest } />
-    );
-  }
+export type SimpleButtonProps = Omit<InputProps, 'type'>;
+
+/** A normal button, but with the "simple-button" css class added. */
+export function SimpleButton(props: SimpleButtonProps) {
+  const { className, ...rest } = props;
+  return (
+    <input
+      type='button'
+      className={'simple-button' + (className ? ' '+className : '')}
+      { ...rest } />
+  );
 }

--- a/src/renderer/components/SizeProvider.tsx
+++ b/src/renderer/components/SizeProvider.tsx
@@ -1,40 +1,41 @@
 import * as React from 'react';
+import { useEffect, useRef } from 'react';
 
-export interface ISizeProviderProps {
-  width: string|number;
-  height: string|number;
+export type SizeProviderProps = {
+  /** Children of the wrapping <div> element. */
+  children?: React.ReactNode;
+  /** Value to set the "--width" CSS variable to. */
+  width: string | number;
+  /** Value to set the "--height" CSS variable to. */
+  height: string | number;
+};
+
+/** Sets and updates the "--width" and "--height" CSS variables to match the prop values. */
+export function SizeProvider(props: SizeProviderProps) {
+  const ref = useRef(null);
+  // Update "--width"
+  useEffect(() => {
+    updateStyle(ref.current, '--width', props.width);
+  }, [ref.current, props.width]);
+  // Update "--height"
+  useEffect(() => {
+    updateStyle(ref.current, '--height', props.height);
+  }, [ref.current, props.height]);
+  // Render
+  return (
+    <div ref={ref}>
+      {props.children}
+    </div>
+  );
 }
 
-export class SizeProvider extends React.Component<ISizeProviderProps> {
-  private _wrapper: React.RefObject<HTMLDivElement> = React.createRef();
-
-  constructor(props: ISizeProviderProps) {
-    super(props);
-  }
-
-  componentDidMount(): void {
-    this.updateCssVars();
-  }
-
-  componentDidUpdate(prevProps: ISizeProviderProps): void {
-    if (prevProps.width  !== this.props.width ||
-        prevProps.height !== this.props.height) {
-      this.updateCssVars();
-    }
-  }
-
-  render() {
-    return (
-      <div ref={this._wrapper}>
-        {this.props.children}
-      </div>
-    );
-  }
-  
-  updateCssVars() {
-    const wrapper = this._wrapper.current;
-    if (!wrapper) { throw new Error('Wrapper element missing'); }
-    wrapper.style.setProperty('--width', this.props.width+'');
-    wrapper.style.setProperty('--height', this.props.height+'');
-  }
+/**
+ * Update the a style property of the style attribute of an element.
+ * @param element Element to update the style attribute of.
+ * @param prop Name of the style property.
+ * @param value Value of the style property.
+ */
+function updateStyle(element: HTMLElement | null, prop: string, value: string | number): void {
+  if (!element) { throw new Error('Can not update CSS variables. Element not found.'); }
+  element.style.setProperty(prop, value+'');
 }

--- a/src/renderer/components/TitleBar.tsx
+++ b/src/renderer/components/TitleBar.tsx
@@ -1,25 +1,26 @@
 import * as React from 'react';
-import { IDefaultProps } from '../interfaces';
 
-export interface ITitleBarProps extends IDefaultProps {
+export type TitleBarProps = {
+  /** Title to display. */
   title?: string;
-}
+};
 
-export class TitleBar extends React.Component<ITitleBarProps> {
-  constructor(props: ITitleBarProps) {
-    super(props);
-  }
-
-  render() {
-    return (
-      <div className="title-bar">
-        <p className="title-bar__title">{this.props.title || ''}</p>
-        <div className="title-bar__button-bar">
-          <div className="title-bar__button-bar__min" onClick={window.External.minimize} />
-          <div className="title-bar__button-bar__max" onClick={window.External.maximize} />
-          <div className="title-bar__button-bar__cross" onClick={window.External.close} />
-        </div>
+/** Title bar of the window (the top-most part of the window). */
+export function TitleBar(props: TitleBarProps) {
+  return (
+    <div className='title-bar'>
+      <p className='title-bar__title'>{props.title || ''}</p>
+      <div className='title-bar__button-bar'>
+        <div
+          className='title-bar__button-bar__min'
+          onClick={window.External.minimize} />
+        <div
+          className='title-bar__button-bar__max'
+          onClick={window.External.maximize} />
+        <div
+          className='title-bar__button-bar__cross'
+          onClick={window.External.close} />
       </div>
-    );
-  }
+    </div>
+  );
 }

--- a/src/renderer/components/pages/AboutPage.tsx
+++ b/src/renderer/components/pages/AboutPage.tsx
@@ -4,29 +4,26 @@ import { ICreditsData, ICreditsDataProfile } from '../../credits/interfaces';
 import { CreditsTooltip } from '../CreditsTooltip';
 import { CreditsIcon } from '../CreditsProfile';
 
-export interface IAboutPageProps {
+export type AboutPageProps = {
+  /** Credits data (if any). */
   creditsData?: ICreditsData;
+  /** If the credits data is done loading (even if it was unsuccessful). */
   creditsDoneLoading: boolean;
-}
+};
 
-export interface IAboutPageState {
-  /** Currently targeted profile */
+export type AboutPageState = {
+  /** Currently "targeted" profile (the profile that the cursor is hovering over, if any). */
   profile?: ICreditsDataProfile;
-}
+};
 
-export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState> {
-  constructor(props: IAboutPageProps) {
-    super(props);
-    this.state = {};
-  }
-
+export class AboutPage extends React.Component<AboutPageProps, AboutPageState> {
   render() {
     const { profile } = this.state;
     const { creditsData, creditsDoneLoading } = this.props;
     return (
       <div className='about-page simple-scroll'>
         <div className='about-page__inner'>
-          <div className="about-page__top">
+          <div className='about-page__top'>
             <h1 className='about-page__title'>About</h1>
             <CreditsTooltip profile={profile} />
             <div className='about-page__columns simple-columns'>
@@ -36,7 +33,7 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
                 <div className='about-page__section'>
                   <p className='about-page__section__title'>BlueMaxima's Flashpoint</p>
                   <div className='about-page__section__content'>
-                    <p className="about-page__section__content__description">
+                    <p className='about-page__section__content__description'>
                       The preservation project this launcher was built for, that aims to be an archive, museum and playable collection of web-based Internet games.
                     </p>
                     <div className='about-page__section__links'>
@@ -49,7 +46,7 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
                 <div className='about-page__section'>
                   <p className='about-page__section__title'>Flashpoint Launcher</p>
                   <div className='about-page__section__content'>
-                    <p className="about-page__section__content__description">
+                    <p className='about-page__section__content__description'>
                       An open-source desktop application used to browse, manage and play games from the Flashpoint project.
                     </p>
                     <p><b>Version:</b> {appVersionString}</p>
@@ -68,9 +65,11 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
                   <div className='about-page__credits__profiles'>
                     { (creditsDoneLoading && creditsData) ? (
                       creditsData.profiles.map((profile, index) => (
-                        <CreditsIcon key={index} profile={profile}
-                                    onMouseEnter={this.onMouseEnterCreditsIcon}
-                                    onMouseLeave={this.onMouseLeaveCreditsIcon}/>
+                        <CreditsIcon
+                          key={index}
+                          profile={profile}
+                          onMouseEnter={this.onMouseEnterCreditsIcon}
+                          onMouseLeave={this.onMouseLeaveCreditsIcon}/>
                       ))
                     ) : ('...') }
                   </div>
@@ -79,10 +78,10 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
             </div>
           </div>
           {/* Bottom */}
-          <div className="about-page__bottom">
-            <div className="about-page__bottom__inner">
-              <p className="about-page__bottom__quote">"It's not up to us to decide what the future finds interesting"</p>
-              <p className="about-page__bottom__author">-Jason Scott</p>
+          <div className='about-page__bottom'>
+            <div className='about-page__bottom__inner'>
+              <p className='about-page__bottom__quote'>"It's not up to us to decide what the future finds interesting"</p>
+              <p className='about-page__bottom__author'>-Jason Scott</p>
             </div>
           </div>
         </div>
@@ -90,13 +89,13 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
     );
   }
   
-  private onMouseEnterCreditsIcon = (profile: ICreditsDataProfile) => {
+  onMouseEnterCreditsIcon = (profile: ICreditsDataProfile) => {
     if (this.state.profile !== profile) {
       this.setState({ profile });
     }
   }
   
-  private onMouseLeaveCreditsIcon = () => {
+  onMouseLeaveCreditsIcon = () => {
     if (this.state.profile !== undefined) {
       this.setState({ profile: undefined });
     }
@@ -104,5 +103,11 @@ export class AboutPage extends React.Component<IAboutPageProps, IAboutPageState>
 }
 
 function link(title: string, url: string): JSX.Element {
-  return (<a href={url} title={url}>{title}</a>);
+  return (
+    <a
+      href={url}
+      title={url}>
+      {title}
+    </a>
+  );
 }

--- a/src/renderer/components/pages/AboutPage.tsx
+++ b/src/renderer/components/pages/AboutPage.tsx
@@ -16,7 +16,13 @@ export type AboutPageState = {
   profile?: ICreditsDataProfile;
 };
 
+/** Page displaying information about this launcher, the "BlueMaxima's Flashpoint" project and its contributors. */
 export class AboutPage extends React.Component<AboutPageProps, AboutPageState> {
+  constructor(props: AboutPageProps) {
+    super(props);
+    this.state = {};
+  }
+
   render() {
     const { profile } = this.state;
     const { creditsData, creditsDoneLoading } = this.props;

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -85,12 +85,14 @@ export type BrowsePageState = {
   suggestions?: Partial<GamePropSuggestions>;
 };
 
+/** Page displaying the games and playlists. */
 export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState> {
   /** Reference of the game grid/list element. */
   gameGridOrListRef: HTMLDivElement | null = null;
   /** A timestamp of the previous the the quick search string was updated */
   _prevQuickSearchUpdate: number = 0;
   gameBrowserRef: React.RefObject<HTMLDivElement> = React.createRef();
+  /** The "setState" function but bound to this instance. */
   boundSetState = this.setState.bind(this);
 
   /** Time it takes before the current "quick search" string to reset after a change was made (in milliseconds). */

--- a/src/renderer/components/pages/ConfigPage.tsx
+++ b/src/renderer/components/pages/ConfigPage.tsx
@@ -19,16 +19,25 @@ type OwnProps = {
 export type ConfigPageProps = OwnProps & WithPreferencesProps;
 
 type ConfigPageState = {
+  /** If the currently entered Flashpoint path points to a "valid" Flashpoint folder (it exists and "looks" like a Flashpoint folder). */
   isFlashpointPathValid?: boolean;
-  // -- Configs --
+  /** Currently entered Flashpoint path. */
   flashpointPath: string;
+  /** If the "use custom title bar" checkbox is checked. */
   useCustomTitlebar: boolean;
+  /** If the "use fiddler" checkbox is checked. */
   useFiddler: boolean;
 };
 
+/**
+ * A page displaying some of the current "configs" / "preferences", as well as a way of changing them.
+ * All changed "configs" (settings stored in "config.json") require you to "Save & Restart" to take effect.
+ * The changed "preferences" (settings stored in "preferences.json") do not require a restart, and are updated directly.
+ * @TODO Make it clear which settings are "configs" and which are "preferences" (or at least which require you to "save & restart")?
+ */
 export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState> {
   /** Reference to the input element of the "current theme" drop-down field. */
-  private currentThemeInputRef: HTMLInputElement | HTMLTextAreaElement | null = null;
+  currentThemeInputRef: HTMLInputElement | HTMLTextAreaElement | null = null;
 
   constructor(props: ConfigPageProps) {
     super(props);
@@ -61,7 +70,9 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                       </div>
                       <div className='setting__row__content setting__row__content--toggle'>
                         <div>
-                          <CheckBox checked={this.props.preferencesData.browsePageShowExtreme} onToggle={this.onShowExtremeChange} />
+                          <CheckBox
+                            checked={this.props.preferencesData.browsePageShowExtreme}
+                            onToggle={this.onShowExtremeChange} />
                         </div>
                       </div>
                     </div>
@@ -78,7 +89,9 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                     </div>
                     <div className='setting__row__content setting__row__content--toggle'>
                       <div>
-                        <CheckBox checked={this.props.preferencesData.enableEditing} onToggle={this.onEnableEditingChange} />
+                        <CheckBox
+                          checked={this.props.preferencesData.enableEditing}
+                          onToggle={this.onEnableEditingChange} />
                       </div>
                     </div>
                   </div>
@@ -98,9 +111,10 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                 <div className='setting__row__top'>
                   <p className='setting__row__title'>Flashpoint Path</p>
                   <div className='setting__row__content setting__row__content--filepath-path'>
-                    <ConfigFlashpointPathInput input={this.state.flashpointPath}
-                                               onInputChange={this.onFlashpointPathChange}
-                                               isValid={this.state.isFlashpointPathValid} />
+                    <ConfigFlashpointPathInput
+                      input={this.state.flashpointPath}
+                      onInputChange={this.onFlashpointPathChange}
+                      isValid={this.state.isFlashpointPathValid} />
                   </div>
                 </div>
                 <div className='setting__row__bottom'>
@@ -115,11 +129,17 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                   </div>
                   <div className='setting__row__content setting__row__content--redirector'>
                     <div>
-                      <input type='radio' checked={!this.state.useFiddler} onChange={this.onRedirectorRedirectorChange}/>
+                      <input
+                        type='radio'
+                        checked={!this.state.useFiddler}
+                        onChange={this.onRedirectorRedirectorChange} />
                       <p>Redirector</p>
                     </div>
                     <div>
-                      <input type='radio' checked={this.state.useFiddler} onChange={this.onRedirectorFiddlerChange}/>
+                      <input
+                        type='radio'
+                        checked={this.state.useFiddler}
+                        onChange={this.onRedirectorFiddlerChange} />
                       <p>Fiddler</p>
                     </div>
                   </div>
@@ -136,7 +156,9 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.props.preferencesData.useWine} onToggle={this.useWineChange} />
+                      <CheckBox
+                        checked={this.props.preferencesData.useWine}
+                        onToggle={this.useWineChange} />
                     </div>
                   </div>
                 </div>
@@ -159,7 +181,9 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.state.useCustomTitlebar} onToggle={this.onUseCustomTitlebarChange} />
+                      <CheckBox
+                        checked={this.state.useCustomTitlebar}
+                        onToggle={this.onUseCustomTitlebarChange} />
                     </div>
                   </div>
                 </div>
@@ -184,7 +208,11 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                       onItemSelect={this.onCurrentThemeItemSelect}
                       inputRef={this.currentThemeInputRefFunc}
                       />
-                    <input type='button' value='Browse' className='simple-button' onClick={this.onCurrentThemeBrowseClick} />
+                    <input
+                      type='button'
+                      value='Browse'
+                      className='simple-button'
+                      onClick={this.onCurrentThemeBrowseClick} />
                   </div>
                 </div>
                 <div className='setting__row__bottom'>
@@ -206,7 +234,9 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.props.preferencesData.showDeveloperTab} onToggle={this.onShowDeveloperTab} />
+                      <CheckBox
+                        checked={this.props.preferencesData.showDeveloperTab}
+                        onToggle={this.onShowDeveloperTab} />
                     </div>
                   </div>
                 </div>
@@ -220,7 +250,11 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
           {/* -- Save & Restart -- */}
           <div className='setting'>
             <div className='setting__row'>
-              <input type='button' value='Save & Restart' className='simple-button save-and-restart' onClick={this.onSaveAndRestartClick} />
+              <input
+                type='button'
+                value='Save & Restart'
+                className='simple-button save-and-restart'
+                onClick={this.onSaveAndRestartClick} />
             </div>
           </div>
         </div>
@@ -228,57 +262,57 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
     );
   }
   
-  private onShowExtremeChange = (isChecked: boolean): void => {
+  onShowExtremeChange = (isChecked: boolean): void => {
     this.props.updatePreferences({ browsePageShowExtreme: isChecked });
     this.forceUpdate();
   }
 
-  private onEnableEditingChange = (isChecked: boolean): void => {
+  onEnableEditingChange = (isChecked: boolean): void => {
     this.props.updatePreferences({ enableEditing: isChecked });
     this.forceUpdate();
   }
 
-  private onRedirectorRedirectorChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  onRedirectorRedirectorChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     this.setState({ useFiddler: !event.target.checked });
   }
-  private onRedirectorFiddlerChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+  onRedirectorFiddlerChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
     this.setState({ useFiddler: event.target.checked });
   }
 
-  /** When the "FlashPoint Folder Path" input text is changed */
-  private onFlashpointPathChange = async (filePath: string): Promise<void> => {
+  /** When the "FlashPoint Folder Path" input text is changed. */
+  onFlashpointPathChange = async (filePath: string): Promise<void> => {
     this.setState({ flashpointPath: filePath });
     // Check if the file-path points at a valid FlashPoint folder
     const isValid = await isFlashpointValidCheck(filePath);
     this.setState({ isFlashpointPathValid: isValid });
   }
   
-  private useWineChange = (isChecked: boolean): void => {
+  useWineChange = (isChecked: boolean): void => {
     this.props.updatePreferences({ useWine: isChecked });
     this.forceUpdate();
   }
   
-  private onUseCustomTitlebarChange = (isChecked: boolean): void => {
+  onUseCustomTitlebarChange = (isChecked: boolean): void => {
     this.setState({ useCustomTitlebar: isChecked });
   }
   
-  private onShowDeveloperTab = (isChecked: boolean): void => {
+  onShowDeveloperTab = (isChecked: boolean): void => {
     this.props.updatePreferences({ showDeveloperTab: isChecked });
     this.forceUpdate();
   }
 
-  private onCurrentThemeChange = (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>): void => {
+  onCurrentThemeChange = (event: React.ChangeEvent<HTMLInputElement|HTMLTextAreaElement>): void => {
     this.props.updatePreferences({ currentTheme: event.currentTarget.value });
   }
 
-  private onCurrentThemeKeyDown = (event: React.KeyboardEvent): void => {
+  onCurrentThemeKeyDown = (event: React.KeyboardEvent): void => {
     if (event.key === 'Enter') {
       // Load the entered theme
       this.props.reloadTheme(this.props.preferencesData.currentTheme);
     }
   }
 
-  private onCurrentThemeItemSelect = (text: string, index: number): void => {
+  onCurrentThemeItemSelect = (text: string, index: number): void => {
     // Note: Suggestions with index 0 to "length - 1" are filenames of themes.
     //       Directly after that comes the "No Theme" suggestion.
     let theme: string | undefined;
@@ -293,7 +327,7 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
     }
   }
 
-  private onCurrentThemeBrowseClick = (event: React.MouseEvent): void => {
+  onCurrentThemeBrowseClick = (event: React.MouseEvent): void => {
     // Synchronously show a "open dialog" (this makes the main window "frozen" while this is open)
     const filePaths = window.External.showOpenDialog({
       title: 'Select a theme file',
@@ -314,12 +348,12 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
     }
   }
   
-  private currentThemeInputRefFunc = (ref: HTMLInputElement | HTMLTextAreaElement | null): void => {
+  currentThemeInputRefFunc = (ref: HTMLInputElement | HTMLTextAreaElement | null): void => {
     this.currentThemeInputRef = ref;
   }
 
-  /** When the "Save & Restart" button is clicked */
-  private onSaveAndRestartClick = () => {
+  /** When the "Save & Restart" button is clicked. */
+  onSaveAndRestartClick = () => {
     // Create new config
     let newConfig = recursiveReplace(deepCopy(window.External.config.data), {
       flashpointPath: this.state.flashpointPath,
@@ -333,6 +367,7 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
   }
 }
 
+/** Format a theme item into a displayable name for the themes drop-down. */
 function formatThemeItemName(item: IThemeListItem): string {
   return `${item.metaData.name} (${item.basename})`;
 }

--- a/src/renderer/components/pages/ConfigPage.tsx
+++ b/src/renderer/components/pages/ConfigPage.tsx
@@ -9,28 +9,28 @@ import { ConfigFlashpointPathInput } from '../ConfigFlashpointPathInput';
 import { DropdownInputField } from '../DropdownInputField';
 import { IThemeListItem } from '../../theme/ThemeManager';
 
-interface OwnProps {
+type OwnProps = {
   /** Filenames of all files in the themes folder. */
   themeItems: IThemeListItem[];
   /** Load and apply a theme. */
   reloadTheme(themePath: string | undefined): void;
-}
+};
 
-export type IConfigPageProps = OwnProps & WithPreferencesProps;
+export type ConfigPageProps = OwnProps & WithPreferencesProps;
 
-export interface IConfigPageState {
+type ConfigPageState = {
   isFlashpointPathValid?: boolean;
   // -- Configs --
   flashpointPath: string;
   useCustomTitlebar: boolean;
   useFiddler: boolean;
-}
+};
 
-export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageState> {
+export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState> {
   /** Reference to the input element of the "current theme" drop-down field. */
   private currentThemeInputRef: HTMLInputElement | HTMLTextAreaElement | null = null;
 
-  constructor(props: IConfigPageProps) {
+  constructor(props: ConfigPageProps) {
     super(props);
     const configData = window.External.config.data;
     this.state = {
@@ -61,7 +61,7 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                       </div>
                       <div className='setting__row__content setting__row__content--toggle'>
                         <div>
-                          <CheckBox checked={this.props.preferencesData.browsePageShowExtreme} onChange={this.onShowExtremeChange} />
+                          <CheckBox checked={this.props.preferencesData.browsePageShowExtreme} onToggle={this.onShowExtremeChange} />
                         </div>
                       </div>
                     </div>
@@ -78,7 +78,7 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                     </div>
                     <div className='setting__row__content setting__row__content--toggle'>
                       <div>
-                        <CheckBox checked={this.props.preferencesData.enableEditing} onChange={this.onEnableEditingChange} />
+                        <CheckBox checked={this.props.preferencesData.enableEditing} onToggle={this.onEnableEditingChange} />
                       </div>
                     </div>
                   </div>
@@ -115,11 +115,11 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                   </div>
                   <div className='setting__row__content setting__row__content--redirector'>
                     <div>
-                      <input type="radio" checked={!this.state.useFiddler} onChange={this.onRedirectorRedirectorChange}/>
+                      <input type='radio' checked={!this.state.useFiddler} onChange={this.onRedirectorRedirectorChange}/>
                       <p>Redirector</p>
                     </div>
                     <div>
-                      <input type="radio" checked={this.state.useFiddler} onChange={this.onRedirectorFiddlerChange}/>
+                      <input type='radio' checked={this.state.useFiddler} onChange={this.onRedirectorFiddlerChange}/>
                       <p>Fiddler</p>
                     </div>
                   </div>
@@ -136,7 +136,7 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.props.preferencesData.useWine} onChange={this.useWineChange} />
+                      <CheckBox checked={this.props.preferencesData.useWine} onToggle={this.useWineChange} />
                     </div>
                   </div>
                 </div>
@@ -159,7 +159,7 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.state.useCustomTitlebar} onChange={this.onUseCustomTitlebarChange} />
+                      <CheckBox checked={this.state.useCustomTitlebar} onToggle={this.onUseCustomTitlebarChange} />
                     </div>
                   </div>
                 </div>
@@ -206,7 +206,7 @@ export class ConfigPage extends React.Component<IConfigPageProps, IConfigPageSta
                   </div>
                   <div className='setting__row__content setting__row__content--toggle'>
                     <div>
-                      <CheckBox checked={this.props.preferencesData.showDeveloperTab} onChange={this.onShowDeveloperTab} />
+                      <CheckBox checked={this.props.preferencesData.showDeveloperTab} onToggle={this.onShowDeveloperTab} />
                     </div>
                   </div>
                 </div>

--- a/src/renderer/components/pages/DeveloperPage.tsx
+++ b/src/renderer/components/pages/DeveloperPage.tsx
@@ -34,6 +34,11 @@ type DeveloperPageState = {
   text: string;
 };
 
+/**
+ * Page made for developers or advanced users only.
+ * It has various "tools" that the user can run to gather information about the current Flashpoint folders data (games, playlists, images etc.), or edit that data on mass.
+ * New tools are added as needed.
+ */
 export class DeveloperPage extends React.Component<DeveloperPageProps, DeveloperPageState> {
   constructor(props: DeveloperPageProps) {
     super(props);
@@ -51,66 +56,86 @@ export class DeveloperPage extends React.Component<DeveloperPageProps, Developer
           This is where all the useful developer tools will go.
           <div className='developer-page__buttons'>
             {/* Top Buttons */}
-            <SimpleButton value='Check Missing Images' onClick={this.onCheckMissingImagesClick}
-                          title='List all games without a thumbnail or screenshot.' />
-            <SimpleButton value='Check Game IDs' onClick={this.onCheckGameIDsClick}
-                          title='List all games with duplicate or invalid IDs' />
-            <SimpleButton value='Check Game Titles' onClick={this.onCheckGameNamesClick}
-                          title='List all games with duplicate titles' />
-            <SimpleButton value='Check Game Fields' onClick={this.onCheckGameFieldsClick}
-                          title='List all games with empty fields (of the fields that should not be empty)' />
-            <SimpleButton value='Check Playlists' onClick={this.onCheckPlaylistsClick}
-                          title='List all playlists with duplicate or invalid IDs, or that has game entries with missing, invalid or duplicate IDs' />
-            <SimpleButton value='Check Game File Location' onClick={this.onCheckFileLocation}
-                          title='List all games with launch commands that can not be parsed into file paths (this is related to the "Open File Location" function, not launching the game).' />
+            <SimpleButton
+              value='Check Missing Images'
+              title='List all games without a thumbnail or screenshot.'
+              onClick={this.onCheckMissingImagesClick} />
+            <SimpleButton
+              value='Check Game IDs'
+              title='List all games with duplicate or invalid IDs'
+              onClick={this.onCheckGameIDsClick} />
+            <SimpleButton
+              value='Check Game Titles'
+              title='List all games with duplicate titles'
+              onClick={this.onCheckGameNamesClick} />
+            <SimpleButton
+              value='Check Game Fields'
+              title='List all games with empty fields (of the fields that should not be empty)'
+              onClick={this.onCheckGameFieldsClick} />
+            <SimpleButton
+              value='Check Playlists'
+              title='List all playlists with duplicate or invalid IDs, or that has game entries with missing, invalid or duplicate IDs'
+              onClick={this.onCheckPlaylistsClick} />
+            <SimpleButton
+              value='Check Game File Location'
+              title='List all games with launch commands that can not be parsed into file paths (this is related to the "Open File Location" function, not launching the game).'
+              onClick={this.onCheckFileLocation} />
             {/* Log */}
-            <LogData className='developer-page__log' logData={text} />
+            <LogData
+              className='developer-page__log'
+              logData={text} />
             {/* Bottom Buttons */}
-            <SimpleButton value='Rename Images (Title => ID)' onClick={this.onRenameImagesTitleToIDClick}
-                          title='Find all game images with the games title in their filename, and rename it to use its ID instead.' />
-            <SimpleButton value='Rename Images (ID => Title)' onClick={this.onRenameImagesIDToTitleClick}
-                          title='Find all game images with the games ID in their filename, and rename it to use its title instead.' />
-            <SimpleButton value='Create Missing Folders' onClick={this.onCreateMissingFoldersClick}
-                          title='Find all missing folders in the Flashpoint folder structure and create them.' />
+            <SimpleButton
+              value='Rename Images (Title => ID)'
+              title='Find all game images with the games title in their filename, and rename it to use its ID instead.'
+              onClick={this.onRenameImagesTitleToIDClick} />
+            <SimpleButton
+              value='Rename Images (ID => Title)'
+              title='Find all game images with the games ID in their filename, and rename it to use its title instead.'
+              onClick={this.onRenameImagesIDToTitleClick} />
+            <SimpleButton
+              value='Create Missing Folders'
+              title='Find all missing folders in the Flashpoint folder structure and create them.'
+              onClick={this.onCreateMissingFoldersClick} />
           </div>
         </div>
       </div>
     );
   }
 
-  private onCheckMissingImagesClick = (): void => {
+  onCheckMissingImagesClick = (): void => {
     const games = this.props.central.games.collection.games;
     const gameImages = this.props.central.gameImages;
     this.setState({ text: checkMissingGameImages(games, gameImages) });
   }
 
-  private onCheckGameIDsClick = (): void => {
+  onCheckGameIDsClick = (): void => {
     const games = this.props.central.games.collection.games;
     this.setState({ text: checkGameIDs(games) });
   }
 
-  private onCheckGameNamesClick = (): void => {
+  onCheckGameNamesClick = (): void => {
     const games = this.props.central.games.collection.games;
     this.setState({ text: checkGameTitles(games) });
   }
 
-  private onCheckGameFieldsClick = (): void => {
+  onCheckGameFieldsClick = (): void => {
     const games = this.props.central.games.collection.games;
     this.setState({ text: checkGameEmptyFields(games) });
   }
 
-  private onCheckPlaylistsClick = (): void => {
+  onCheckPlaylistsClick = (): void => {
     const playlists = this.props.central.playlists.playlists;
     const games = this.props.central.games.collection.games;
     this.setState({ text: checkPlaylists(playlists, games) });
   }
 
-  private onCheckFileLocation = (): void => {
+  onCheckFileLocation = (): void => {
     const games = this.props.central.games.collection.games;
     this.setState({ text: checkFileLocation(games) });
   }
 
-  private onRenameImagesTitleToIDClick = (): void => {
+  onRenameImagesTitleToIDClick = (): void => {
     this.setState({ text: 'Please be patient. This may take a few seconds (or minutes)...' });
     setTimeout(async () => {
       const games = this.props.central.games.collection.games;
@@ -119,7 +144,7 @@ export class DeveloperPage extends React.Component<DeveloperPageProps, Developer
     }, 0);
   }
 
-  private onRenameImagesIDToTitleClick = (): void => {
+  onRenameImagesIDToTitleClick = (): void => {
     this.setState({ text: 'Please be patient. This may take a few seconds (or minutes)...' });
     setTimeout(async () => {
       const games = this.props.central.games.collection.games;
@@ -128,7 +153,7 @@ export class DeveloperPage extends React.Component<DeveloperPageProps, Developer
     }, 0);
   }
 
-  private onCreateMissingFoldersClick = (): void => {
+  onCreateMissingFoldersClick = (): void => {
     setTimeout(async () => {
       const collection = this.props.central.games.collection;
       this.setState({ text: await createMissingFolders(collection) });

--- a/src/renderer/components/pages/DeveloperPage.tsx
+++ b/src/renderer/components/pages/DeveloperPage.tsx
@@ -5,7 +5,7 @@ import * as uuidValidate from 'uuid-validate';
 import { IGameInfo } from '../../../shared/game/interfaces';
 import { removeFileExtension } from '../../../shared/Util';
 import { GameImageCollection } from '../../image/GameImageCollection';
-import { ICentralState } from '../../interfaces';
+import { CentralState } from '../../interfaces';
 import { IGamePlaylist, IGamePlaylistEntry } from '../../playlist/interfaces';
 import { validateSemiUUID } from '../../uuid';
 import { LogData } from '../LogData';
@@ -22,18 +22,20 @@ const rename = promisify(fs.rename);
 const exists = promisify(fs.exists);
 const mkdir  = promisify(fs.mkdir);
 
-interface IOwnProps {
-  central: ICentralState;
-}
+type OwnProps = {
+  /** Semi-global prop. */
+  central: CentralState;
+};
 
-type IDeveloperPageProps = IOwnProps & WithLibraryProps;
+type DeveloperPageProps = OwnProps & WithLibraryProps;
 
-interface IDeveloperPageState {
+type DeveloperPageState = {
+  /** Text of the log. */
   text: string;
-}
+};
 
-export class DeveloperPage extends React.Component<IDeveloperPageProps, IDeveloperPageState> {
-  constructor(props: IDeveloperPageProps) {
+export class DeveloperPage extends React.Component<DeveloperPageProps, DeveloperPageState> {
+  constructor(props: DeveloperPageProps) {
     super(props);
     this.state = {
       text: '',

--- a/src/renderer/components/pages/HomePage.tsx
+++ b/src/renderer/components/pages/HomePage.tsx
@@ -6,7 +6,7 @@ import { IGameInfo } from '../../../shared/game/interfaces';
 import { WithLibraryProps } from '../../containers/withLibrary';
 import { WithPreferencesProps } from '../../containers/withPreferences';
 import { GameLauncher } from '../../GameLauncher';
-import { ICentralState, UpgradeStageState } from '../../interfaces';
+import { CentralState, UpgradeStageState } from '../../interfaces';
 import { Paths } from '../../Paths';
 import { IGamePlaylist } from '../../playlist/interfaces';
 import { IUpgradeStage } from '../../upgrade/upgrade';
@@ -18,28 +18,23 @@ import { findDefaultLibrary } from '../../../shared/library/util';
 import { WithSearchProps } from '../../containers/withSearch';
 import { getPlatforms } from '../../util/platform';
 
-interface OwnProps {
-  central: ICentralState;
+type OwnProps = {
+  /** Semi-global prop. */
+  central: CentralState;
   onSelectPlaylist: (playlist?: IGamePlaylist, route?: string) => void;
+  /** Clear the current search query (resets the current search filters). */
   clearSearch: () => void;
+  /** Called when the "download tech" button is clicked. */
   onDownloadTechUpgradeClick: () => void;
+  /** Called when the "download screenshots" button is clicked. */
   onDownloadScreenshotsUpgradeClick: () => void;
-}
+};
 
-export type IHomePageProps = OwnProps & WithPreferencesProps & WithLibraryProps & WithSearchProps;
+export type HomePageProps = OwnProps & WithPreferencesProps & WithLibraryProps & WithSearchProps;
 
-export interface IHomePageState {
-  /** Delay applied to the logo's animation */
-  logoDelay: string;
-}
-
-export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
-  constructor(props: IHomePageProps) {
-    super(props);
-    this.state = {
-      logoDelay: (Date.now() * -0.001) + 's', // (Offset the animation with the current time stamp)
-    };
-  }
+export class HomePage extends React.Component<HomePageProps> {
+  /** Offset of the starting point in the animated logo's animation (sync it with time of the machine). */
+  logoDelay = (Date.now() * -0.001) + 's';
 
   render() {
     const {
@@ -61,19 +56,18 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     const upgradeData = this.props.central.upgrade.data;
     const { showBrokenGames } = window.External.config.data;
     const { disableExtremeGames } = window.External.config.data;
-    const { logoDelay } = this.state;
-
-    // Grabs a dynamic list of supported platforms and preformats them as Links
+    // Grabs a dynamic list of supported platforms and pre-formats them as Links
     const platformList = getPlatforms(this.props.central.games.collection);
     const formatPlatforms = platformList.map((platform, index) =>
       <span key={index}> 
-        <Link to={joinLibraryRoute('arcade')} onClick={this.onPlatformClick(platform)}>
+        <Link
+          to={joinLibraryRoute('arcade')}
+          onClick={this.onPlatformClick(platform)}>
           {platform}
         </Link>
         { (index < platformList.length -1) ? ', ' : undefined }
       </span>
     );
-    
     // (These are kind of "magic numbers" and the CSS styles are designed to fit with them)
     const height: number = 140;
     const width: number = (height * 0.666) | 0;
@@ -82,7 +76,9 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
         <div className='home-page__inner'>
           {/* Logo */}
           <div className='home-page__logo'>
-            <div className='home-page__logo__image' style={{ animationDelay:logoDelay }} />
+            <div
+              className='home-page__logo__image'
+              style={{ animationDelay: this.logoDelay }} />
           </div>
           {/* Quick Start */}
           <div className='home-page__box'>
@@ -122,21 +118,33 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
             <div className='home-page__box__head'>Extras</div>
             <ul className='home-page__box__body'>
               <QuickStartItem icon='heart'>
-                <Link to={this.getFavoriteBrowseRoute()} onClick={this.onFavoriteClick}>Favorites Playlist</Link>
+                <Link
+                  to={this.getFavoriteBrowseRoute()}
+                  onClick={this.onFavoriteClick}>
+                  Favorites Playlist
+                </Link>
               </QuickStartItem>
               <QuickStartItem icon='list'>
-                <a href="http://bluemaxima.org/flashpoint/datahub/Genres" target="_top">Genre List</a>
+                <a
+                  href='http://bluemaxima.org/flashpoint/datahub/Genres'
+                  target='_top'>
+                  Genre List
+                </a>
               </QuickStartItem>
-                <br></br>
+              <br />
               <QuickStartItem icon='tag'>
                 Filter by platform: 
               </QuickStartItem>
               <QuickStartItem>
                 { formatPlatforms }
               </QuickStartItem>
-                <br></br>
+              <br />
               <QuickStartItem icon='code'>
-                <a href="https://trello.com/b/Tu9E5GLk/launcher" target="_top">Check out our planned features!</a>
+                <a
+                  href='https://trello.com/b/Tu9E5GLk/launcher'
+                  target='_top'>
+                  Check out our planned features!
+                </a>
               </QuickStartItem>
             </ul>
           </div>
@@ -175,7 +183,7 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     );
   }
 
-  private renderStageSection(stageData: IUpgradeStage|undefined, stageState: UpgradeStageState, onClick: () => void) {
+  renderStageSection(stageData: IUpgradeStage|undefined, stageState: UpgradeStageState, onClick: () => void) {
     return (
       <>
         <QuickStartItem><b>{stageData && stageData.title || '...'}</b></QuickStartItem>
@@ -185,7 +193,7 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     );
   }
 
-  private renderStageButton(stageState: UpgradeStageState, onClick: () => void) {
+  renderStageButton(stageState: UpgradeStageState, onClick: () => void) {
     return (
       stageState.checksDone ? (
         stageState.alreadyInstalled ? (
@@ -197,7 +205,11 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
             stageState.isInstalling ? (
               <p>{stageState.installProgressNote}</p>
             ) : (
-              <a className='simple-button' onClick={onClick}>Download</a>
+              <a
+                className='simple-button'
+                onClick={onClick}>
+                Download
+              </a>
             )            
           )
         )
@@ -205,16 +217,16 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     );
   }
 
-  private onLaunchGame(game: IGameInfo): void {
+  onLaunchGame(game: IGameInfo): void {
     GameLauncher.launchGame(game);
   }
 
-  private onHelpClick = () => {
+  onHelpClick = () => {
     const fullFlashpointPath = window.External.config.fullFlashpointPath;
     remote.shell.openItem(path.join(fullFlashpointPath, 'readme.txt'));
   }
 
-  private onHallOfFameClick = () => {
+  onHallOfFameClick = () => {
     const { central, libraryData, onSelectPlaylist } = this.props;
     let hof = findHallOfFamePlaylist(central.playlists.playlists);
     let route: string|undefined = undefined;
@@ -228,10 +240,10 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     onSelectPlaylist(hof, route);
   }
 
-  private onFavoriteClick = () => {
+  onFavoriteClick = () => {
     const { central, libraryData, onSelectPlaylist } = this.props;
     let fav = findFavoritePlaylist(central.playlists.playlists);
-    let route: string|undefined = undefined;
+    let route: string | undefined = undefined;
     if (fav) {
       if (fav.library) { route = fav.library; }
       else {
@@ -242,22 +254,22 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     onSelectPlaylist(fav, route);
   }
 
-  private onAllGamesClick = () => {
+  onAllGamesClick = () => {
     this.props.onSelectPlaylist(undefined, 'arcade');
     this.props.clearSearch();
   }
 
-  private onAllAnimationsClick = () => {
+  onAllAnimationsClick = () => {
     this.props.onSelectPlaylist(undefined, 'theatre');
     this.props.clearSearch();
   }
 
   // Gets the platform as a string and performs a search dynamically for each platform generated
-  private onPlatformClick = (platform: string) => (event: any) => {
+  onPlatformClick = (platform: string) => (event: any) => {
     this.props.onSearch('!' + platform);
   }
 
-  private getHallOfFameBrowseRoute = (): string => {
+  getHallOfFameBrowseRoute = (): string => {
     const defaultLibrary = this.props.libraryData.libraries.find(library => !!library.default);
     const defaultRoute = defaultLibrary ? joinLibraryRoute(defaultLibrary.route) : Paths.BROWSE;
     let hof = findHallOfFamePlaylist(this.props.central.playlists.playlists);
@@ -265,7 +277,7 @@ export class HomePage extends React.Component<IHomePageProps, IHomePageState> {
     else                    { return defaultRoute;                  }
   }
 
-  private getFavoriteBrowseRoute = (): string => {
+  getFavoriteBrowseRoute = (): string => {
     const defaultLibrary = this.props.libraryData.libraries.find(library => !!library.default);
     const defaultRoute = defaultLibrary ? joinLibraryRoute(defaultLibrary.route) : Paths.BROWSE;
     let fav = findFavoritePlaylist(this.props.central.playlists.playlists);

--- a/src/renderer/components/pages/HomePage.tsx
+++ b/src/renderer/components/pages/HomePage.tsx
@@ -32,6 +32,7 @@ type OwnProps = {
 
 export type HomePageProps = OwnProps & WithPreferencesProps & WithLibraryProps & WithSearchProps;
 
+/** Page shown as soon as the application starts up. */
 export class HomePage extends React.Component<HomePageProps> {
   /** Offset of the starting point in the animated logo's animation (sync it with time of the machine). */
   logoDelay = (Date.now() * -0.001) + 's';
@@ -113,7 +114,7 @@ export class HomePage extends React.Component<HomePageProps> {
               </div>
             ) : undefined
           }
-          {/* Additional info - Trello request */}
+          {/* Extras */}
           <div className='home-page__box home-page__box--extras'>
             <div className='home-page__box__head'>Extras</div>
             <ul className='home-page__box__body'>
@@ -229,7 +230,7 @@ export class HomePage extends React.Component<HomePageProps> {
   onHallOfFameClick = () => {
     const { central, libraryData, onSelectPlaylist } = this.props;
     let hof = findHallOfFamePlaylist(central.playlists.playlists);
-    let route: string|undefined = undefined;
+    let route: string | undefined = undefined;
     if (hof) {
       if (hof.library) { route = hof.library; }
       else {
@@ -264,7 +265,7 @@ export class HomePage extends React.Component<HomePageProps> {
     this.props.clearSearch();
   }
 
-  // Gets the platform as a string and performs a search dynamically for each platform generated
+  /** Gets the platform as a string and performs a search dynamically for each platform generated. */
   onPlatformClick = (platform: string) => (event: any) => {
     this.props.onSearch('!' + platform);
   }
@@ -301,10 +302,10 @@ function QuickStartItem(props: { icon?: OpenIconType, className?: string, childr
   );
 }
 
-function findHallOfFamePlaylist(playlists: IGamePlaylist[]): IGamePlaylist|undefined {
+function findHallOfFamePlaylist(playlists: IGamePlaylist[]): IGamePlaylist | undefined {
   return playlists.find(playlist => playlist.title === 'Flashpoint Hall of Fame');
 }
 
-function findFavoritePlaylist(playlists: IGamePlaylist[]): IGamePlaylist|undefined {
+function findFavoritePlaylist(playlists: IGamePlaylist[]): IGamePlaylist | undefined {
   return playlists.find(playlist => playlist.title === '*Favorites*');
 }

--- a/src/renderer/components/pages/LogsPage.tsx
+++ b/src/renderer/components/pages/LogsPage.tsx
@@ -19,6 +19,7 @@ const labels = [
   'Router',
 ];
 
+/** Page displaying this launcher's log. */
 export class LogsPage extends React.Component<LogsPageProps> {
   stringifyLogEntriesMemo = memoizeOne(stringifyLogEntries, stringifyLogEntriesEquals);
 

--- a/src/renderer/components/pages/LogsPage.tsx
+++ b/src/renderer/components/pages/LogsPage.tsx
@@ -8,10 +8,9 @@ import { WithPreferencesProps } from '../../containers/withPreferences';
 import { Dropdown } from '../Dropdown';
 import { LogData } from '../LogData';
 
-interface OwnProps {
-}
+type OwnProps = {};
 
-export type ILogsPageProps = OwnProps & WithPreferencesProps;
+export type LogsPageProps = OwnProps & WithPreferencesProps;
 
 const labels = [
   'Background Services',
@@ -20,14 +19,10 @@ const labels = [
   'Router',
 ];
 
-export class LogsPage extends React.Component<ILogsPageProps> {
-  private stringifyLogEntriesMemo = memoizeOne(stringifyLogEntries, stringifyLogEntriesEquals);
+export class LogsPage extends React.Component<LogsPageProps> {
+  stringifyLogEntriesMemo = memoizeOne(stringifyLogEntries, stringifyLogEntriesEquals);
 
-  constructor(props: ILogsPageProps) {
-    super(props);
-  }
-
-  private getLogString() {
+  getLogString() {
     const logEntries = Object.assign([], window.External.log.entries);
     const filter = Object.assign({}, this.props.preferencesData.showLogSource);
     return this.stringifyLogEntriesMemo(logEntries, filter);
@@ -54,9 +49,11 @@ export class LogsPage extends React.Component<ILogsPageProps> {
               { labels.map((label, index) => (
                 <label key={index}>
                   <div className='simple-center'>
-                    <input type='checkbox' checked={getBoolean(showLogSource[label])}
-                           onChange={() => this.onCheckboxClick(index)}
-                           className='simple-center__vertical-inner' />               
+                    <input
+                      type='checkbox'
+                      checked={getBoolean(showLogSource[label])}
+                      onChange={() => this.onCheckboxClick(index)}
+                      className='simple-center__vertical-inner' />               
                   </div>
                   <div className='simple-center'>
                     <p className='simple-center__vertical-inner'>{label}</p>                  
@@ -72,15 +69,21 @@ export class LogsPage extends React.Component<ILogsPageProps> {
                 {/* Copy Button */}
                 <div className='log-page__bar__wrap'>
                   <div>
-                    <input type='button' value='Copy Text' onClick={this.onCopyClick}
-                           className='simple-button simple-center__vertical-inner' />
+                    <input
+                      type='button'
+                      value='Copy Text'
+                      onClick={this.onCopyClick}
+                      className='simple-button simple-center__vertical-inner' />
                   </div>
                 </div>
                 {/* Clear Button */}
                 <div className='log-page__bar__wrap'>
                   <div className='simple-center'>
-                    <input type='button' value='Clear Log' onClick={this.onClearClick}
-                           className='simple-button simple-center__vertical-inner' />
+                    <input
+                      type='button'
+                      value='Clear Log'
+                      onClick={this.onClearClick}
+                      className='simple-button simple-center__vertical-inner' />
                   </div>
                 </div>
                 {/* Add more right stuff here ... */}
@@ -89,22 +92,25 @@ export class LogsPage extends React.Component<ILogsPageProps> {
           </div>
         </div>
         {/* Content */}
-        <LogData className='log-page__content' logData={logData} isLogDataHTML={true} />
+        <LogData
+          className='log-page__content'
+          logData={logData}
+          isLogDataHTML={true} />
       </div>
     );
   }
 
-  private onCopyClick = (): void => {
+  onCopyClick = (): void => {
     if (!navigator.clipboard) { throw new Error('Clipboard API is not available.'); }
     const logData = this.getLogString();
     navigator.clipboard.writeText(parseHtmlToText(logData));
   }
 
-  private onClearClick = (): void => {
+  onClearClick = (): void => {
     window.External.log.clearEntries();
   }
 
-  private onCheckboxClick = (index: number): void => {
+  onCheckboxClick = (index: number): void => {
     const label = labels[index];
     const { showLogSource } = this.props.preferencesData;
     this.props.updatePreferences({
@@ -116,15 +122,15 @@ export class LogsPage extends React.Component<ILogsPageProps> {
     });
   }
 
-  private onLogDataUpdate = (log: LogRendererApi): void => {
+  onLogDataUpdate = (log: LogRendererApi): void => {
     this.forceUpdate();
   }
 }
 
 /**
- * Parse a HTML string into plain text (potentially unsafe)
- * @param text HTML string
- * @returns text representation of HTML
+ * Parse a HTML string into plain text (potentially unsafe).
+ * @param text HTML string.
+ * @returns text representation of HTML.
  */
 function parseHtmlToText(text: string): string {
   const element = document.createElement('div');
@@ -132,6 +138,7 @@ function parseHtmlToText(text: string): string {
   return element.innerText;
 }
 
+/** Convert "boolean | undefined" to "boolean" (undefined is converted to true). */
 function getBoolean(value?: boolean): boolean {
   return (value === undefined) ? true : value;
 }

--- a/src/renderer/components/pages/NotFoundPage.tsx
+++ b/src/renderer/components/pages/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+/** Page shown when the current URL does not point to an existing page. */
 export const NotFoundPage: React.StatelessComponent<{}> = () => {
   return (
     <div className='page-not-found'>

--- a/src/renderer/containers/ConnectedBrowsePage.ts
+++ b/src/renderer/containers/ConnectedBrowsePage.ts
@@ -1,28 +1,30 @@
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { Subtract } from 'utility-types';
-import { BrowsePage, IBrowsePageProps } from '../components/pages/BrowsePage';
+import { BrowsePage, BrowsePageProps } from '../components/pages/BrowsePage';
 import { ApplicationState } from '../store';
 import { SearchQuery } from '../store/search';
 import * as searchActions from '../store/search/actions';
 import { withLibrary, WithLibraryProps } from './withLibrary';
 import { withPreferences, WithPreferencesProps } from './withPreferences';
 
-interface IStateToProps {
+type StateToProps = {
+  /** The most recent search query. */
   search: SearchQuery;
-}
+};
 
-interface IDispatchToProps {
+type DispatchToProps = {
+  /** Clear the current search query (resets the current search filters). */
   clearSearch: () => void;
-}
+};
 
-export type IConnectedBrowsePageProps = Subtract<IBrowsePageProps, IStateToProps & IDispatchToProps & WithPreferencesProps & WithLibraryProps>;
+export type ConnectedBrowsePageProps = Subtract<BrowsePageProps, StateToProps & DispatchToProps & WithPreferencesProps & WithLibraryProps>;
 
-const mapStateToProps = ({ search }: ApplicationState): IStateToProps => ({
+const mapStateToProps = ({ search }: ApplicationState): StateToProps => ({
   search: search.query,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch): IDispatchToProps => bindActionCreators({
+const mapDispatchToProps = (dispatch: Dispatch): DispatchToProps => bindActionCreators({
   clearSearch: () => searchActions.setQuery({ text: '' }),
 }, dispatch);
 

--- a/src/renderer/containers/ConnectedConfigPage.ts
+++ b/src/renderer/containers/ConnectedConfigPage.ts
@@ -1,7 +1,7 @@
 import { Subtract } from 'utility-types';
-import { ConfigPage, IConfigPageProps } from '../components/pages/ConfigPage';
+import { ConfigPage, ConfigPageProps } from '../components/pages/ConfigPage';
 import { withPreferences, WithPreferencesProps } from './withPreferences';
 
-export type IConnectedConfigPageProps = Subtract<IConfigPageProps, WithPreferencesProps>;
+export type ConnectedConfigPageProps = Subtract<ConfigPageProps, WithPreferencesProps>;
 
 export const ConnectedConfigPage = withPreferences(ConfigPage);

--- a/src/renderer/containers/ConnectedHomePage.ts
+++ b/src/renderer/containers/ConnectedHomePage.ts
@@ -1,19 +1,20 @@
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
 import { Subtract } from 'utility-types';
-import { HomePage, IHomePageProps } from '../components/pages/HomePage';
+import { HomePage, HomePageProps } from '../components/pages/HomePage';
 import * as searchActions from '../store/search/actions';
 import { withLibrary, WithLibraryProps } from './withLibrary';
 import { withSearch, WithSearchProps } from './withSearch';
 import { withPreferences, WithPreferencesProps } from './withPreferences';
 
-interface IDispatchToProps {
+type DispatchToProps = {
+  /** Clear the current search query (resets the current search filters). */
   clearSearch: () => void;
-}
+};
 
-export type IConnectedHomePageProps = Subtract<IHomePageProps, IDispatchToProps & WithPreferencesProps & WithLibraryProps & WithSearchProps>;
+export type ConnectedHomePageProps = Subtract<HomePageProps, DispatchToProps & WithPreferencesProps & WithLibraryProps & WithSearchProps>;
 
-const mapDispatchToProps = (dispatch: Dispatch): IDispatchToProps => bindActionCreators({
+const mapDispatchToProps = (dispatch: Dispatch): DispatchToProps => bindActionCreators({
   clearSearch: () => searchActions.setQuery({ text: '' }),
 }, dispatch);
 

--- a/src/renderer/containers/HeaderContainer.tsx
+++ b/src/renderer/containers/HeaderContainer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
-import { Header, IHeaderProps } from '../components/Header';
+import { Header, HeaderProps } from '../components/Header';
 import { ApplicationState } from '../store';
 import * as searchActions from '../store/search/actions';
 import { joinLibraryRoute } from '../Util';
@@ -10,15 +10,13 @@ import { withLibrary, WithLibraryProps } from './withLibrary';
 import { withPreferences } from './withPreferences';
 import { withSearch, WithSearchProps } from './withSearch';
 
-interface IStateToProps {
-}
+type StateToProps = {};
 
-interface IDispatchToProps {
-}
+type DispatchToProps = {};
 
-type IHeaderContainerProps = IHeaderProps & IStateToProps & IDispatchToProps & WithSearchProps & WithLibraryProps;
+type HeaderContainerProps = HeaderProps & StateToProps & DispatchToProps & WithSearchProps & WithLibraryProps;
 
-const HeaderContainer: React.FunctionComponent<IHeaderContainerProps> = (props: IHeaderContainerProps) => {
+const HeaderContainer: React.FunctionComponent<HeaderContainerProps> = (props: HeaderContainerProps) => {
   const { onSearch, ...rest } = props;
   return (
     <Header
@@ -27,16 +25,16 @@ const HeaderContainer: React.FunctionComponent<IHeaderContainerProps> = (props: 
         if (redirect) { props.history.push(joinLibraryRoute(props.preferencesData.lastSelectedLibrary)); }
         onSearch(text);
       }}
-      {...rest}
+      { ...rest }
     />
   );  
 }
 
-const mapStateToProps = ({ search }: ApplicationState): IStateToProps => ({
+const mapStateToProps = ({ search }: ApplicationState): StateToProps => ({
   search: search.query
 });
 
-const mapDispatchToProps = (dispatch: Dispatch): IDispatchToProps => bindActionCreators({
+const mapDispatchToProps = (dispatch: Dispatch): DispatchToProps => bindActionCreators({
   onSearch: (text: string) => searchActions.setQuery({ text }),
 }, dispatch);
 

--- a/src/renderer/containers/withLibrary.tsx
+++ b/src/renderer/containers/withLibrary.tsx
@@ -4,17 +4,19 @@ import { IGameLibraryFile } from '../../shared/library/interfaces';
 import { ApplicationState } from '../store';
 import * as action from '../store/library/actions';
 
-interface IStateToProps {
+type StateToProps = {
+  /** Data of the current library. */
   readonly libraryData: Readonly<IGameLibraryFile>;
-}
+};
 
-interface IDispatchToProps {
+type DispatchToProps = {
+  /** Update the data of the current library (in the state, not the file). */
   readonly updateLibrary: (data: Partial<IGameLibraryFile>) => void;
-}
+};
 
-export type WithLibraryProps = IStateToProps & IDispatchToProps;
+export type WithLibraryProps = StateToProps & DispatchToProps;
 
-const mapStateToProps = ({ library }: ApplicationState): IStateToProps => ({
+const mapStateToProps = ({ library }: ApplicationState): StateToProps => ({
   libraryData: library.data,
 });
 

--- a/src/renderer/containers/withPreferences.tsx
+++ b/src/renderer/containers/withPreferences.tsx
@@ -4,17 +4,19 @@ import { IAppPreferencesData } from '../../shared/preferences/IAppPreferencesDat
 import { ApplicationState } from '../store';
 import * as action from '../store/preferences/actions';
 
-interface IStateToProps {
+type StateToProps = {
+  /** Current preference data. */
   readonly preferencesData: Readonly<IAppPreferencesData>;
-}
+};
 
-interface IDispatchToProps {
+type DispatchToProps = {
+  /** Update the entire, or parts of the, preference data object. */
   readonly updatePreferences: (data: Partial<IAppPreferencesData>) => void;
-}
+};
 
-export type WithPreferencesProps = IStateToProps & IDispatchToProps;
+export type WithPreferencesProps = StateToProps & DispatchToProps;
 
-const mapStateToProps = ({ preferences }: ApplicationState): IStateToProps => ({
+const mapStateToProps = ({ preferences }: ApplicationState): StateToProps => ({
   preferencesData: preferences.data,
 });
 

--- a/src/renderer/containers/withSearch.tsx
+++ b/src/renderer/containers/withSearch.tsx
@@ -4,17 +4,19 @@ import { ApplicationState } from '../store';
 import { SearchQuery } from '../store/search';
 import * as searchActions from '../store/search/actions';
 
-interface IStateToProps {
+type StateToProps = {
+  /** Query of the most recent search. */
   searchQuery: SearchQuery;
-}
+};
 
-interface IDispatchToProps {
+type DispatchToProps = {
+  /** Called when the user attempts to make a search. */
   onSearch: (text: string) => void;
-}
+};
 
-export type WithSearchProps = IStateToProps & IDispatchToProps;
+export type WithSearchProps = StateToProps & DispatchToProps;
 
-const mapStateToProps = ({ search }: ApplicationState): IStateToProps => ({
+const mapStateToProps = ({ search }: ApplicationState): StateToProps => ({
   searchQuery: search.query,
 });
 

--- a/src/renderer/hooks/useConfirm.ts
+++ b/src/renderer/hooks/useConfirm.ts
@@ -1,0 +1,77 @@
+import { useCallback, useReducer } from 'react';
+
+type ActivateCallback = () => void;
+type ConfirmCallback = () => void;
+type ResetCallback = () => void;
+
+type ConfirmState = {
+  /** Number of times it has been activated since the last reset. */
+  count: number;
+};
+
+type ConfirmAction = ({
+  type: 'reset',
+} | {
+  type: 'increment',
+  limit: number,
+  confirm: () => void,
+});
+
+const confirmDefaultState: ConfirmState = Object.freeze({
+  count: 0,
+});
+
+function confirmReducer(state: ConfirmState, action: ConfirmAction): ConfirmState {
+  switch (action.type) {
+    case 'increment':
+      let nextCount = state.count + 1;
+      if (nextCount > action.limit) {
+        action.confirm();
+        nextCount = 0;
+      }
+      return { count: nextCount };
+    case 'reset':
+      return { count: 0 };
+    default:
+      throw new Error(`Invalid action "${action}".`);
+  }
+}
+
+type ConfirmReturn = [
+  /** Number of times this has been activated since the last reset. */
+  number, // (count)
+  /** Increments "count" (and then calls "onConfirm" if the counter exceeds "limit"). */
+  ActivateCallback,
+  /** Calls the "onConfirm" callback (does not change or reset "count") */
+  ConfirmCallback,
+  /** Resets "count". */
+  ResetCallback
+];
+
+/**
+ * 
+ * @param confirmLimit Number of activations needed to confirm.
+ * @param onConfirm Called when confirmed.
+ */
+export function useConfirm(confirmLimit?: number, onConfirm?: () => void): ConfirmReturn {
+  const [state, dispatch] = useReducer(confirmReducer, confirmDefaultState);
+  // Default limit
+  const limit = (confirmLimit === undefined) ? 1 : confirmLimit;
+  // Confirm callback
+  const confirm = useCallback(() => {
+    console.log('confirm');
+    if (onConfirm) { onConfirm(); }
+  }, [onConfirm]);
+  // Reset callback
+  const reset = useCallback(() => {
+    console.log('reset');
+    dispatch({ type: 'reset' });
+  }, [dispatch]);
+  // Activate callback
+  const activate = useCallback(() => {
+    console.log('activate');
+    dispatch({ type: 'increment', limit, confirm });
+  }, [dispatch, limit, confirm, reset]);
+  // Return
+  return [state.count, activate, confirm, reset];
+}

--- a/src/renderer/interfaces.ts
+++ b/src/renderer/interfaces.ts
@@ -1,74 +1,53 @@
-import { ReactNode } from 'react';
 import GameManager from './game/GameManager';
 import { GameImageCollection } from './image/GameImageCollection';
 import { GamePlaylistManager } from './playlist/GamePlaylistManager';
 import { IUpgradeData } from './upgrade/upgrade';
 
-/** "match" object from 'react-router' and 'history' npm packages */
-export interface IMatch {
-  /** Key/value pairs parsed from the URL corresponding to the dynamic segments of the path */
-  params: any;
-  /** true if the entire URL was matched (no trailing characters) */
-  isExact: boolean;
-  /** The path pattern used to match. Useful for building nested <Route>s */
-  path: string;
-  /** The matched portion of the URL. Useful for building nested <Link>s */
-  url: string;
-}
-
-export interface IDefaultProps {
-  children?: ReactNode;
-}
-
 /**
- * An object that contains useful stuff and is passed throughout the react app as a prop/state
- * (This should be temporary and used for quick and dirty testing and implementation)
- * (Replace this with something more thought out and maintainable once the project has more structure)
+ * An object created and managed by the "root" component (App) and is passed down deep into many different components.
+ * This is sort of a hacky and temporary solution. It should be phased out.
  */
-export interface ICentralState {
-  /** All playlists */
+export type CentralState = {
+  /** Manager of all the games, and container of the loaded and parsed game data. */
   games: GameManager;
-  /** Lookup table for all games images filenames */
+  /** Manager of all the game image folders, and container of their data. */
   gameImages: GameImageCollection;
-  /** All playlists */
+  /** Manager of all playlists. */
   playlists: GamePlaylistManager;
-  /** @TODO write this comment */
+  /** Data and state used for the upgrade system (optional install-able downloads from the HomePage). */
   upgrade: UpgradeState;
-  /** If the game collection is done loading */
+  /** If all the games are done loading (even if it was unsuccessful). */
   gamesDoneLoading: boolean;
-  /** If the game collection failed to load */
+  /** If the games failed to load (this value is only meaningful after the games are done loading). */
   gamesFailedLoading: boolean;
-  /** If the playlist collection is done loading */
+  /** If all the playlists are done loading (even if it was unsuccessful). */
   playlistsDoneLoading: boolean;
-  /** If the playlist failed to load */
+  /** If the playlists failed to load (this value is only meaningful after the playlists are done loading). */
   playlistsFailedLoading: boolean;
-}
+};
 
-/**
- * State of the current search.
- */
-export interface SearchState {
-  input: string;
-}
-
-/** @TODO write this comment */
-export interface UpgradeState {
+/** Data and state used for the upgrade system. */
+export type UpgradeState = {
+  /** Data from the upgrade file (or the defaults if it failed to load or parse). */
   data?: IUpgradeData;
+  /** State of the tech stage. */
   techState: UpgradeStageState;
+  /** State of the screenshots stage. */
   screenshotsState: UpgradeStageState;
-  /** If the "upgrade" file has been loaded and parsed (or if it failed and the default values were used instead) */
+  /** If the upgrade JSON is done loading (even if it was unsuccessful). */
   doneLoading: boolean;
-}
+};
 
-export interface UpgradeStageState {
-  /** If the stage was already installed when the launcher started up */
+/** State of a single "stage" in the upgrade system (each individual downloadable upgrade is called a "stage"). */
+export type UpgradeStageState = {
+  /** If the stage was already installed when the launcher started up (this value is only meaningful if the stage checks are done). */
   alreadyInstalled: boolean;
-  /** If the checks has been performed */
+  /** If the checks has been performed (this is to check if the stage has already been installed). */
   checksDone: boolean;
-  /** If the stage is currently being downloaded / installed */
+  /** If the stage is currently being downloaded or installed. */
   isInstalling: boolean;
-  /** If the stage was installed during this session (this is so it can tell the user to restart) */
+  /** If the stage was installed during this session (this is so the user can be told to restart the application). */
   isInstallationComplete: boolean;
-  /** Progress note of the installation (if its being installed) */
+  /** Current progress note of the installation (visible text meant to inform the user about the current progress of the download or install). */
   installProgressNote: string;
-}
+};

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -37,7 +37,7 @@ export type AppRouterProps = {
   reloadTheme: (themePath: string | undefined) => void;
 };
 
-export class AppRouter extends React.Component<AppRouterProps, {}> {
+export class AppRouter extends React.Component<AppRouterProps> {
   render() {
     const homeProps: ConnectedHomePageProps = {
       central: this.props.central,

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -2,25 +2,27 @@ import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { BrowsePageLayout } from '../shared/BrowsePageLayout';
 import { IGameInfo } from '../shared/game/interfaces';
-import { IGameOrderChangeEvent } from './components/GameOrder';
-import { AboutPage, IAboutPageProps } from './components/pages/AboutPage';
+import { GameOrderChangeEvent } from './components/GameOrder';
+import { AboutPage, AboutPageProps } from './components/pages/AboutPage';
 import { NotFoundPage } from './components/pages/NotFoundPage';
-import ConnectedBrowsePage, { IConnectedBrowsePageProps } from './containers/ConnectedBrowsePage';
-import { ConnectedConfigPage, IConnectedConfigPageProps } from './containers/ConnectedConfigPage';
-import { ConnectedHomePage, IConnectedHomePageProps } from './containers/ConnectedHomePage';
+import ConnectedBrowsePage, { ConnectedBrowsePageProps } from './containers/ConnectedBrowsePage';
+import { ConnectedConfigPage, ConnectedConfigPageProps } from './containers/ConnectedConfigPage';
+import { ConnectedHomePage, ConnectedHomePageProps } from './containers/ConnectedHomePage';
 import { ConnectedLogsPage } from './containers/ConnectedLogsPage';
-import { ICentralState } from './interfaces';
+import { CentralState } from './interfaces';
 import { Paths } from './Paths';
 import { IGamePlaylist } from './playlist/interfaces';
 import { ConnectedDeveloperPage } from './containers/ConnectedDeveloperPage';
 import { ICreditsData } from './credits/interfaces';
 import { IThemeListItem } from './theme/ThemeManager';
 
-export interface IAppRouterProps {
-  central: ICentralState;
+export type AppRouterProps = {
+  /** Semi-global prop. */
+  central: CentralState;
+  /** Credits data (if any). */
   creditsData?: ICreditsData;
   creditsDoneLoading: boolean;
-  order?: IGameOrderChangeEvent;
+  order?: GameOrderChangeEvent;
   gameScale: number;
   gameLayout: BrowsePageLayout;
   selectedGame?: IGameInfo;
@@ -33,17 +35,17 @@ export interface IAppRouterProps {
   gameLibraryRoute: string;
   themeItems: IThemeListItem[];
   reloadTheme: (themePath: string | undefined) => void;
-}
+};
 
-export class AppRouter extends React.Component<IAppRouterProps, {}> {
+export class AppRouter extends React.Component<AppRouterProps, {}> {
   render() {
-    const homeProps: IConnectedHomePageProps = {
+    const homeProps: ConnectedHomePageProps = {
       central: this.props.central,
       onSelectPlaylist: this.props.onSelectPlaylist,
       onDownloadTechUpgradeClick: this.props.onDownloadTechUpgradeClick,
       onDownloadScreenshotsUpgradeClick: this.props.onDownloadScreenshotsUpgradeClick,
     };
-    const browseProps: IConnectedBrowsePageProps = {
+    const browseProps: ConnectedBrowsePageProps = {
       central: this.props.central,
       order: this.props.order,
       gameScale: this.props.gameScale,
@@ -55,44 +57,54 @@ export class AppRouter extends React.Component<IAppRouterProps, {}> {
       wasNewGameClicked: this.props.wasNewGameClicked,
       gameLibraryRoute: this.props.gameLibraryRoute,
     };
-    const configProps: IConnectedConfigPageProps = {
+    const configProps: ConnectedConfigPageProps = {
       themeItems: this.props.themeItems,
       reloadTheme: this.props.reloadTheme
     };
-    const aboutProps: IAboutPageProps = {
+    const aboutProps: AboutPageProps = {
       creditsData: this.props.creditsData,
       creditsDoneLoading: this.props.creditsDoneLoading
     };
     return (
       <Switch>
-        <PropsRoute exact path={Paths.HOME} component={ConnectedHomePage}
-                    {...homeProps} />
-        <PropsRoute path={Paths.BROWSE} component={ConnectedBrowsePage}
-                    {...browseProps} />
-        <PropsRoute path={Paths.LOGS} component={ConnectedLogsPage} />
-        <PropsRoute path={Paths.CONFIG} component={ConnectedConfigPage}
-                    {...configProps} />
-        <PropsRoute path={Paths.ABOUT} component={AboutPage}
-                    {...aboutProps} />
-        <PropsRoute path={Paths.DEVELOPER} component={ConnectedDeveloperPage}
-                    central={this.props.central} />
+        <PropsRoute
+          exact
+          path={Paths.HOME}
+          component={ConnectedHomePage}
+          { ...homeProps } />
+        <PropsRoute
+          path={Paths.BROWSE}
+          component={ConnectedBrowsePage}
+          { ...browseProps } />
+        <PropsRoute
+          path={Paths.LOGS}
+          component={ConnectedLogsPage} />
+        <PropsRoute
+          path={Paths.CONFIG}
+          component={ConnectedConfigPage}
+          { ...configProps } />
+        <PropsRoute
+          path={Paths.ABOUT}
+          component={AboutPage}
+          { ...aboutProps } />
+        <PropsRoute
+          path={Paths.DEVELOPER}
+          component={ConnectedDeveloperPage}
+          central={this.props.central} />
         <Route component={NotFoundPage} />
       </Switch>
     );
   }
 }
 
-// Reusable way to pass properties down a router and to its component
-const renderMergedProps = (component: any, ...rest: any[]) => {
+/** Reusable way to pass properties down a router and to its component. */
+const PropsRoute = ({ component, ...rest }: any) => (
+  <Route
+    { ...rest }
+    render={routeProps => renderMergedProps(component, routeProps, rest)} />
+);
+
+function renderMergedProps(component: any, ...rest: any[]) {
   const finalProps = Object.assign({}, ...rest);
-  return (
-    React.createElement(component, finalProps)
-  );
-}
-const PropsRoute = ({ component, ...rest }: any) => {
-  return (
-    <Route {...rest} render={routeProps => {
-      return renderMergedProps(component, routeProps, rest);
-    }}/>
-  );
+  return React.createElement(component, finalProps);
 }

--- a/src/renderer/upgrade/upgrade.ts
+++ b/src/renderer/upgrade/upgrade.ts
@@ -6,19 +6,19 @@ import { doAsyncParallel } from '../util/async';
 const upgradeFilePath: string = './upgrade.json';
 const upgradeFileEncoding: string = 'utf8';
 
-export interface IUpgradeData {
+export type IUpgradeData = {
   tech: IUpgradeStage;
   screenshots: IUpgradeStage;
-}
+};
 
-export interface IUpgradeStage {
+export type IUpgradeStage = {
   title: string;
   description: string;
   /** Paths of files that should exist if the stage is "installed" (paths are relative to the flashpoint root) */
   checks: string[];
   /** URLs from where the stage can be downloaded (only one will be downloaded, the other are "backups") */
   sources: string[];
-}
+};
 
 /** Check if all the "checks" of a stage are present */
 export async function performUpgradeStageChecks(stage: IUpgradeStage, flashpointFolder: string): Promise<boolean[]> {

--- a/src/shared/game/GameFilter.ts
+++ b/src/shared/game/GameFilter.ts
@@ -1,4 +1,4 @@
-import { IGameOrderChangeEvent } from '../../renderer/components/GameOrder';
+import { GameOrderChangeEvent } from '../../renderer/components/GameOrder';
 import { IGamePlaylist } from '../../renderer/playlist/interfaces';
 import { GameInfo } from './GameInfo';
 import { IGameInfo, IGameSearchQuery } from './interfaces';
@@ -51,7 +51,7 @@ export function reverseOrder(compareFn: OrderFn): OrderFn {
 }
 
 /** Get the order function for a given game order */
-export function getOrderFunction(order: IGameOrderChangeEvent): OrderFn {
+export function getOrderFunction(order: GameOrderChangeEvent): OrderFn {
   let orderFn: OrderFn;
   switch (order.orderBy) {
     case 'dateAdded': orderFn = orderByDateAdded; break;
@@ -189,7 +189,7 @@ export interface IOrderGamesArgs {
   broken: boolean;
   playlist?: IGamePlaylist;
   platforms?: string[];
-  order: IGameOrderChangeEvent;
+  order: GameOrderChangeEvent;
 }
 
 export function orderGames(args: IOrderGamesArgs): IGameInfo[] {


### PR DESCRIPTION
Comment about the first commit (this reflects the changes made in the other commit as well):

Almost all components have been changed to various degrees to make them
(among other things) easier to read and understand.
These changes include (but are not limited to):
- Add comments to almost all prop and state properties
- Remove the "private" keyword from all(?) properties of components
- Convert many interfaces into types
- Rewrite some class components as function components (with hooks)
- Remove the character "I" from the beginning of prop and state names
- Remove unnecessary constructors from components
- Change to a new "convention" for indenting JSX/TSX (read more below)

The new "convention" for JSX/TSX is very similar to the previous one,
the only thing that changed is how to indent props.
The new "convention" can be explained like this:
All React Elements (<a>these things</a>) with more than one prop
should separate all props with a new line. The props on these lines
should be indented one "step" further than the React Element tag(s).
Example of React Element before this "convention" (not a real example):
```
<div className='link-container' ref={containerRef}
     onClick={onContainerClick}>
  <a href='/home'>Home</a>
  <a href='/browse'>Browse</a>
</div>
```
The same React Element but with the new "convention":
```
<div
  className='link-container'
  ref={containerRef}
  onClick={onContainerClick}>
  <a href='/home'>Home</a>
  <a href='/browse'>Browse</a>
</div>
```