### PR TITLE
renderer/Util.ts tests and removing some unused functions

### DIFF
--- a/src/renderer/Util.ts
+++ b/src/renderer/Util.ts
@@ -7,27 +7,6 @@ export const gameIdDataType: string = 'text/game-id';
 export const gameScaleSpan = 0.6;
 
 /**
- * Calls a defined callback function on each property of an object, and returns an array that contains the results.
- * Similar to Array#map but iterates over the properties of an object.
- * @param source The object who's properties this will iterate over
- * @param callbackfn This is called once per property in the object.
- * @param thisArg What the "this" keyword will refer to inside the callback function (undefined if omitted)
- */
-export function forEach<T, U>(source: any, callbackfn: (value: T, key: string) => U, thisArg?: any): any[] {
-  const array: any[] = [];
-  let index:number = 0;
-  for (let key in source) {
-    array[index++] = callbackfn.call(thisArg, source[key], key);
-  }
-  return array;
-};
-
-/** Linear interpolation between (and beyond) two values */
-export function lerp(from: number, to: number, value: number): number {
-  return from + (to - from) * value;
-}
-
-/**
  * Get the path of the icon for a given platform (could point to a non-existing file)
  * @param platform Platform to get icon of (case sensitive)
  */

--- a/tests/src/renderer/Util.test.ts
+++ b/tests/src/renderer/Util.test.ts
@@ -27,6 +27,10 @@ describe('Util.joinLibraryRoute()', function (){
     const route: string = "..";
     expect(joinLibraryRoute(route)).toBe('/browse');
   });
+  test("Double dots with slashes", () => {
+    const route: string = "a/../b//c";
+    expect(joinLibraryRoute(route)).toBe('/browse/a..bc');
+  });
 });
 
 // findElementAncestor() - to be tested (may need mocks)

--- a/tests/src/renderer/Util.test.ts
+++ b/tests/src/renderer/Util.test.ts
@@ -1,0 +1,32 @@
+/* Tests for src/main/renderer/Util.ts */
+import { shuffle, joinLibraryRoute } from "../../../src/renderer/Util";
+
+// getPlatformIconPath() - to be tested (may need mocks)
+
+// easterEgg() - to be tested (may need mocks)
+
+describe('Util.shuffle()', function () {
+  const list: any[] = [9, "12", 29, "Hello", 3.9, "Flashpoint", -90];
+  expect(shuffle(list)).not.toBe([ 9, "12", 29, "Hello", 3.9, "Flashpoint", -90 ]);
+});
+
+describe('Util.joinLibraryRoute()', function (){
+  test("Empty Route", () => {
+    const route: string = "";
+    expect(joinLibraryRoute(route)).toBe('/browse');
+  });
+  test("Passing a route", () => {
+    const route: string = "arcade";
+    expect(joinLibraryRoute(route)).toBe('/browse/arcade');
+  });
+  test("Lots of slashes", () => {
+    const route: string = "arcade/flash/plugin/shockwa///ve"
+    expect(joinLibraryRoute(route)).toBe('/browse/arcadeflashpluginshockwave');
+  });
+  test("Double dots", () => {
+    const route: string = "..";
+    expect(joinLibraryRoute(route)).toBe('/browse');
+  });
+});
+
+// findElementAncestor() - to be tested (may need mocks)


### PR DESCRIPTION
Refers to #22.

 A few tests for src/renderer/Util.ts:
- shuffle() - just checking that it doesn't return the exact array
- joinLibraryRoute() - making sure it's handling slashes properly

The others look more complicated to test - possibly will have to mock DOM Window objects since getPlatformIconPath() complains that it doesn't exist.

Since I'm wading in these files, I also noticed that `forEach()` and `lerp()` never get referenced anywhere in the code - if you're alright with that, I've gotten rid of them for the sake of bettering our code coverage, if not, happy to roll it back. Trying to keep changes in one file as opposed to multiple like last time.

-----

One thing I also wanted to bring up is that a lot of the functions are private and hard to test. One solution I saw was to use a dependency called rewire that apparently temporarily adds access to private methods for testing. However, adding more dependencies is not really great. It also doesn't seem to be actively maintained. 

Another is just adding the `export` key to these functions, but I'm not sure if that's a great idea. What do you think about it? 