### PR TITLE
Set Wineprefix and surpress Wine messages

### DIFF
--- a/src/renderer/GameLauncher.ts
+++ b/src/renderer/GameLauncher.ts
@@ -266,7 +266,7 @@ export class GameLauncher {
     if(command.startsWith(`"wine"`)){
       var path = require('path');
       var prefix = path.join(window.External.config.fullFlashpointPath, 'FPSoftware/wineprefix');
-      opts.env = Object.assign(opts.env, {'WINEPREFIX': prefix});
+      opts.env = Object.assign(opts.env, {'WINEPREFIX': prefix, "WINEDEBUG": "-all"});
     }
     
     // Run

--- a/src/renderer/GameLauncher.ts
+++ b/src/renderer/GameLauncher.ts
@@ -262,6 +262,13 @@ export class GameLauncher {
   }
 
   private static launch(command: string, opts: ExecOptions): ChildProcess {
+    // Wine - Add packaged wineprefix to env variables
+    if(command.startsWith(`"wine"`)){
+      var path = require('path');
+      var prefix = path.join(window.External.config.fullFlashpointPath, 'FPSoftware/wineprefix');
+      opts.env = Object.assign(opts.env, {'WINEPREFIX': prefix});
+    }
+    
     // Run
     const proc = exec(command, opts);
     // Log for debugging purposes


### PR DESCRIPTION
Apparently suppressing them can cause a speed increase, but generally just makes the log much cleaner. Consider adding a wine debug toggle for it later?

https://wiki.winehq.org/FAQ#I_get_lots_of_.22fixme:.22_messages_in_the_terminal_and_Wine_runs_a_bit_slow