### PR TITLE
Adding basic tests for src/renderer/uuid.ts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
 };

--- a/tests/src/renderer/uuid.test.ts
+++ b/tests/src/renderer/uuid.test.ts
@@ -1,26 +1,30 @@
 /* Tests for src/renderer/uuid.test.ts */
-import { validateSemiUUID } from "../../../src/renderer/uuid";
+import { validateSemiUUID, uuid } from "../../../src/renderer/uuid";
 
-// uuid() wants window property - probably needs to be mocked 
+describe("uuid.uuid()", function () {
+  test("Returns string of proper length?", () => {
+    expect(uuid()).toHaveLength(36);
+  });
+});
 
 describe("uuid.validateSemiUUID()", function () {
   test("Empty string", () => {
     expect(validateSemiUUID("")).toBe(false);
   });
   test("Under 36 characters", () => {
-    const str: string = "12345678abc";
+    const str: string = '12345678abc';
     expect(validateSemiUUID(str)).toBe(false);
   });
   test("Over 36 characters", () => {
-    const str: string = "asdhbgfgfgajk123214543612312323asadghfga";
+    const str: string = 'asdhbgfgfgajk123214543612312323asadghfga';
     expect(validateSemiUUID(str)).toBe(false);
   });
   test("Invalid hexidecimal characters", () => {
-    const str: string = "bbzz1234-0abc-llll-abcd-abc12345678z";
+    const str: string = 'bbzz1234-0abc-llll-abcd-abc12345678z';
     expect(validateSemiUUID(str)).toBe(false);
   });
   test("Valid UUID", () => {
-    const str: string = "0123abcd-fee2-0987-dfea-cd341234cdef";
+    const str: string = '0123abcd-fee2-0987-dfea-cd341234cdef';
     expect(validateSemiUUID(str)).toBe(true);
   });
 });

--- a/tests/src/renderer/uuid.test.ts
+++ b/tests/src/renderer/uuid.test.ts
@@ -1,0 +1,26 @@
+/* Tests for src/renderer/uuid.test.ts */
+import { validateSemiUUID } from "../../../src/renderer/uuid";
+
+// uuid() wants window property - probably needs to be mocked 
+
+describe("uuid.validateSemiUUID()", function () {
+  test("Empty string", () => {
+    expect(validateSemiUUID("")).toBe(false);
+  });
+  test("Under 36 characters", () => {
+    const str: string = "12345678abc";
+    expect(validateSemiUUID(str)).toBe(false);
+  });
+  test("Over 36 characters", () => {
+    const str: string = "asdhbgfgfgajk123214543612312323asadghfga";
+    expect(validateSemiUUID(str)).toBe(false);
+  });
+  test("Invalid hexidecimal characters", () => {
+    const str: string = "bbzz1234-0abc-llll-abcd-abc12345678z";
+    expect(validateSemiUUID(str)).toBe(false);
+  });
+  test("Valid UUID", () => {
+    const str: string = "0123abcd-fee2-0987-dfea-cd341234cdef";
+    expect(validateSemiUUID(str)).toBe(true);
+  });
+});


### PR DESCRIPTION
What the title says - some basic Jest tests for `validateSemiUUID()`. The other export function probably needs to be mocked (the 'ole window object complaint). 

Let me know if I missed an edge case to test. 