### PR TITLE
Various fixes and improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -273,7 +273,9 @@
     "selectThemeFile": "Select Theme File",
     "selectCurationFolder": "Select Curation Folder(s)",
     "selectCurationArchive": "Select Curation Archive(s)",
-    "selectCurationMeta": "Select Curation Meta(s)"
+    "selectCurationMeta": "Select Curation Meta(s)",
+    "errorParsingPlatforms": "Error parsing platforms!",
+    "errorParsingPlatformsMessage": "{0} Error(s) raised while parsing platform XMLs\nPlease check the logs for details."
   },
   "libraries": {
     "arcade": "Games",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -271,7 +271,9 @@
     "selectThemeFile": "Selecione um Ficheiro de Tema",
     "selectCurationFolder": "Selecione Pasta(s) Preservadas",
     "selectCurationArchive": "Selecione Arquivo(s) Preservados",
-    "selectCurationMeta": "Selecione Metadado(s) Preservados"
+    "selectCurationMeta": "Selecione Metadado(s) Preservados",
+    "errorParsingPlatforms": "Erro ao analisar as plataformas!",
+    "errorParsingPlatformsMessage": "{0} Erro(s)  encontrados durante a análise da plataforma XMLs\nPorfavor verificar os logs por detalhes"
   },
   "libraries": {
     "arcade": "Jogos",

--- a/src/renderer/GameLauncher.ts
+++ b/src/renderer/GameLauncher.ts
@@ -110,6 +110,7 @@ export class GameLauncher {
       case 'html5':
       case 'popcap plugin':
       case 'silverlight':
+      default:
         return GameLauncher.getPathOfHtdocsUrl(game.launchCommand, ffpPath);
     }
   }

--- a/src/renderer/LaunchboxData.tsx
+++ b/src/renderer/LaunchboxData.tsx
@@ -31,8 +31,8 @@ export class LaunchboxData {
               fs.stat(path.posix.join(folderPath, fileName), (err: NodeJS.ErrnoException | null, stats: fs.Stats) => {
                 if (err) { reject(err); }
                 else {
-                  // Add to array if it is a file
-                  if (stats.isFile()) {
+                  // Add to array if it is an XML file
+                  if (stats.isFile() && fileName.endsWith('.xml')) {
                     fileNames.push(fileName);
                   }
                   // Decrement counter and check if this was the last file
@@ -140,7 +140,7 @@ export class LaunchboxData {
             // @TODO Look into which settings are most appropriate
           });
           if (!data) {
-            reject(new Error('Failed to parse XML'));
+            reject(new Error('Failed to parse XML file - ' + source));
             return;
           }
           // Make sure the sub-object exists

--- a/src/renderer/curate/parse.ts
+++ b/src/renderer/curate/parse.ts
@@ -75,6 +75,8 @@ function convertMeta(data: any, onError?: (error: string) => void): ParsedCurati
   parser.prop('Tags',                 v => parsed.game.genre               = str(v));
   parser.prop('Title',                v => parsed.game.title               = str(v));
   parser.prop('Version',              v => parsed.game.version             = str(v));
+  // property aliases
+  parser.prop('Animation Notes',      v => parsed.game.notes               = str(v));
   // Add-apps
   parser.prop('Additional Applications').map((item, label, map) => {
     parsed.addApps.push(convertAddApp(item, label, map[label]));

--- a/src/renderer/game/GameManager.ts
+++ b/src/renderer/game/GameManager.ts
@@ -38,6 +38,7 @@ class GameManager extends EventEmitter {
         resolve(); // No files found
       } else {
         let done: number = 0;
+        let errors: any[] = [];
         for (let i = this.platforms.length - 1; i >= 0; i--) {
           const platform = this.platforms[i];
           LaunchboxData.loadPlatform(path.join(flashpointPath, LaunchboxData.platformsPath, platform.filename))
@@ -45,12 +46,20 @@ class GameManager extends EventEmitter {
             platform.data = data;
             platform.collection = new GameCollection().push(GameParser.parse(data, platform.filename));
             this.collection.push(platform.collection);
+          })
+          .catch((error) => {
+            errors.push(error);
+          })
+          .finally(() => {
             done++;
             if (done === this.platforms.length) {
-              resolve();
+              if (errors.length > 0) {
+                reject(errors);
+              } else {
+                resolve();
+              }
             }
-          })
-          .catch(reject);
+          });
         }
       }
     });

--- a/src/renderer/util/lang.ts
+++ b/src/renderer/util/lang.ts
@@ -283,6 +283,8 @@ export function getDefaultLocalization(): LangContainer {
       selectCurationFolder: 'selectCurationFolder',
       selectCurationArchive: 'selectCurationArchive',
       selectCurationMeta: 'selectCurationMeta',
+      errorParsingPlatforms: 'errorParsingPlatforms',
+      errorParsingPlatformsMessage: '{0} errorParsingPlatformsMessage'
     },
     libraries: {},
   };

--- a/src/shared/Util.ts
+++ b/src/shared/Util.ts
@@ -337,3 +337,15 @@ export function versionNumberToText(version: number): string {
     }
   }
 }
+
+/**
+ * Create a copy of an array with all the undefined values taken out (shifting everything along to not leave any empty spaces).
+ * @param array Array to copy and clear.
+ */
+export function clearArray<T>(array: Array<T | undefined>): Array<T> {
+  const clear: T[] = [];
+  for (let val of array) {
+    if (val !== undefined) { clear.push(val); }
+  }
+  return clear;
+}

--- a/src/shared/lang/types.ts
+++ b/src/shared/lang/types.ts
@@ -327,7 +327,9 @@ export type DialogLang = LangObject<
   'selectThemeFile' |
   'selectCurationFolder' |
   'selectCurationArchive' |
-  'selectCurationMeta'
+  'selectCurationMeta' |
+  'errorParsingPlatforms' |
+  'errorParsingPlatformsMessage'
 >;
 
 export type LibrariesLang = Partial<LangObject<string>>;


### PR DESCRIPTION
**fix: Open File Location fallback for missing platforms** - https://trello.com/c/xuhF1ygo

**feat: Notes alias for animations (meta)** - https://discordapp.com/channels/432708847304704010/496132309498724391/620819857314676736

**fix: Improvements to Platform XML parsing and Footer counter** - https://trello.com/c/mVgie98Q and https://trello.com/c/AyRLaSHv

Changes platform XML parsing to only parse files ending in .xml. If it fails to parse a file, it stores the error and rejects them all in an array after the rest have finished parsing. These are printed to the log and the user is warned that *N* platform xmls have failed to parse, and to check the log for details.

Failed XML parsing no longer sets gamesFailedLoading (only set if the platforms path is missing entirely, aka Flashpoint path unset)