### PR TITLE
feat: Developer and Publisher order opts

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -90,6 +90,8 @@
     "platform": "Platform",
     "series": "Series",
     "title": "Title",
+    "developer": "Developer",
+    "publisher": "Publisher",
     "ascending": "Ascending",
     "descending": "Descending"
   },

--- a/src/renderer/components/GameOrder.tsx
+++ b/src/renderer/components/GameOrder.tsx
@@ -40,6 +40,8 @@ export class GameOrder extends React.Component<GameOrderProps> {
           <option value='platform'>{strings.platform}</option>
           <option value='series'>{strings.series}</option>
           <option value='title'>{strings.title}</option>
+          <option value='developer'>{strings.developer}</option>
+          <option value='publisher'>{strings.publisher}</option>
         </select>
         {/* Order Reverse */}
         <select
@@ -89,6 +91,8 @@ function validateOrderBy(value: string): GameOrderBy {
     case 'platform':  return 'platform';
     case 'series':    return 'series';
     case 'title':     return 'title';
+    case 'developer': return 'developer';
+    case 'publisher': return 'publisher';
     default: throw new Error(`"${value}" is not a valid GameOrderBy`);
   }
 }

--- a/src/renderer/util/lang.ts
+++ b/src/renderer/util/lang.ts
@@ -95,9 +95,10 @@ export function getDefaultLocalization(): LangContainer {
       platform: 'platform',
       series: 'series',
       title: 'title',
+      developer: 'developer',
+      publisher: 'publisher',
       ascending: 'ascending',
-      descending: 'descending',
-      developer: 'developer'
+      descending: 'descending'
     },
     developer:{
       developerHeader: 'developerHeader',

--- a/src/shared/game/GameFilter.ts
+++ b/src/shared/game/GameFilter.ts
@@ -23,7 +23,7 @@ export function orderByGenre(a: IGameInfo, b: IGameInfo): number {
 export function orderByDateAdded(a: IGameInfo, b: IGameInfo): number {
   if (a.dateAdded < b.dateAdded) { return -1; }
   if (a.dateAdded > b.dateAdded) { return  1; }
-  return 0;
+  return 0; 
 }
 
 /** Order games by their series alphabetically (ascending) */
@@ -40,6 +40,20 @@ export function orderByPlatform(a: IGameInfo, b: IGameInfo): number {
   return orderByTitle(a, b);
 }
 
+/** Order games by their developer alphabetically (ascending) */
+export function orderByDeveloper(a: IGameInfo, b: IGameInfo): number {
+  if (a.developer < b.developer) { return -1; }
+  if (a.developer > b.developer) { return  1; }
+  return orderByTitle(a, b);
+}
+
+/** Order games by their publisher alphabetically (ascending) */
+export function orderByPublisher(a: IGameInfo, b: IGameInfo): number {
+  if (a.publisher < b.publisher) { return -1; }
+  if (a.publisher > b.publisher) { return  1; }
+  return orderByTitle(a, b);
+}
+
 /** Reverse the order (makes an ascending order function descending instead) */
 export function reverseOrder(compareFn: OrderFn): OrderFn {
   return (a: IGameInfo, b: IGameInfo) => {
@@ -53,11 +67,14 @@ export function reverseOrder(compareFn: OrderFn): OrderFn {
 /** Get the order function for a given game order */
 export function getOrderFunction(order: GameOrderChangeEvent): OrderFn {
   let orderFn: OrderFn;
+  console.log(order);
   switch (order.orderBy) {
     case 'dateAdded': orderFn = orderByDateAdded; break;
     case 'genre':     orderFn = orderByGenre;     break;
     case 'platform':  orderFn = orderByPlatform;  break;
     case 'series':    orderFn = orderBySeries;    break;
+    case 'developer': orderFn = orderByDeveloper; break;
+    case 'publisher': orderFn = orderByPublisher; break;
     default: /* case 'title': */ orderFn = orderByTitle; break;
   }
   if (order.orderReverse === 'descending') {

--- a/src/shared/game/GameFilter.ts
+++ b/src/shared/game/GameFilter.ts
@@ -23,7 +23,7 @@ export function orderByGenre(a: IGameInfo, b: IGameInfo): number {
 export function orderByDateAdded(a: IGameInfo, b: IGameInfo): number {
   if (a.dateAdded < b.dateAdded) { return -1; }
   if (a.dateAdded > b.dateAdded) { return  1; }
-  return 0; 
+  return 0;
 }
 
 /** Order games by their series alphabetically (ascending) */

--- a/src/shared/game/GameFilter.ts
+++ b/src/shared/game/GameFilter.ts
@@ -67,7 +67,6 @@ export function reverseOrder(compareFn: OrderFn): OrderFn {
 /** Get the order function for a given game order */
 export function getOrderFunction(order: GameOrderChangeEvent): OrderFn {
   let orderFn: OrderFn;
-  console.log(order);
   switch (order.orderBy) {
     case 'dateAdded': orderFn = orderByDateAdded; break;
     case 'genre':     orderFn = orderByGenre;     break;

--- a/src/shared/lang/types.ts
+++ b/src/shared/lang/types.ts
@@ -133,6 +133,7 @@ export type FilterLang = LangObject<
   'series' |
   'title' |
   'developer' |
+  'publisher' |
   'ascending' |
   'descending'
 >;

--- a/src/shared/order/interfaces.ts
+++ b/src/shared/order/interfaces.ts
@@ -1,5 +1,5 @@
 /** Properties to order games by */
-export type GameOrderBy = 'dateAdded'|'genre'|'platform'|'series'|'title';
+export type GameOrderBy = 'dateAdded'|'genre'|'platform'|'series'|'title'|'developer'|'publisher';
 
 /** Ways to order games */
 export type GameOrderReverse = 'ascending'|'descending';

--- a/src/shared/order/util.ts
+++ b/src/shared/order/util.ts
@@ -1,7 +1,7 @@
 import { GameOrderBy, GameOrderReverse } from './interfaces';
 
 /** An array with all valid values of GameOrderBy */
-export const gameOrderByOptions: GameOrderBy[] = [ 'dateAdded', 'genre', 'platform', 'series', 'title' ];
+export const gameOrderByOptions: GameOrderBy[] = [ 'dateAdded', 'genre', 'platform', 'series', 'title', 'developer', 'publisher' ];
 
 /** An array with all valid values of GameOrderReverse */
 export const gameOrderReverseOptions: GameOrderReverse[] = [ 'ascending', 'descending' ];


### PR DESCRIPTION
https://trello.com/c/VIedDh0p

Should use `has:developer` and `has:publisher` filters from reworked search system if you don't wish to see empty developer/publisher entries.