### PR TITLE
feat: Biased random games

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -59,7 +59,8 @@
     "notes": "Don't forget to read the readme if you're having issues.",
     "linuxSupport": "Issues on Linux? {0}",
     "linuxSupportLinkText": "Open FAQ",
-    "randomPicks": "Random Picks"
+    "randomPicks": "Random Picks",
+    "reroll": "Re-roll"
   },
   "logs": {
     "filters": "Filters",

--- a/src/renderer/components/RandomGames.tsx
+++ b/src/renderer/components/RandomGames.tsx
@@ -6,6 +6,7 @@ import { GameImageCollection } from '../image/GameImageCollection';
 import { findElementAncestor, shuffle } from '../Util';
 import { GameGridItem } from './GameGridItem';
 import { GameItemContainer } from './GameItemContainer';
+import { LangContext } from '../util/lang';
 
 type RandomGamesProps = {
   /** Games to randomly pick from. */
@@ -22,21 +23,26 @@ type RandomGamesProps = {
 
 /** The number of games shown in the RandomGames component. */
 const numberOfGames = 6;
+/** Number of times to re-roll for unique genre */
+const rolls = 10;
 
 /** A small "grid" of randomly selected games. */
 export function RandomGames(props: RandomGamesProps) {
-  // Select random games to display
-  const randomGames = useMemo(() => {
-    const filteredGames = filterBroken(props.showBroken, filterExtreme(props.showExtreme, props.games));
-    const shuffledGames = shuffle(filteredGames);
-    const randomGames = shuffledGames.slice(0, Math.min(numberOfGames, props.games.length));
-    return randomGames;
-  }, [/* Only pick games on the first render. */]);
+  const strings = React.useContext(LangContext).home;
+  // Filter the given selection
+  const filteredGames = useMemo(() => {
+    return filterBroken(props.showBroken, filterExtreme(props.showExtreme, props.games));
+  }, [/* Only filter games on the first render. */]);
+  // Keep a state of the random games
+  const [randomGames, setRandomGames] = React.useState(getRandomGames(filteredGames));
+
   // Launch Callback
   const onGameLaunch = useCallback((event: React.MouseEvent, gameId: string) => {
     const game = randomGames.find(game => game.id === gameId);
+    console.log(game);
     if (game) { props.onLaunchGame(game); }
-  }, []);
+  }, [randomGames]);
+
   // Render games
   const gameItems = React.useMemo(() => (
     randomGames.map(game => (
@@ -48,14 +54,22 @@ export function RandomGames(props: RandomGamesProps) {
         isDragged={false} />
     ))
   ), [randomGames, props.gameImages]);
+
   // Render
   return (
-    <GameItemContainer
-      className='random-games'
-      onGameLaunch={onGameLaunch}
-      findGameId={findGameId}>
-      { gameItems }
-    </GameItemContainer>
+    <div>
+      <p className='home-page__random-games__title'>{strings.randomPicks}</p>
+      <button
+        className='simple-button home-page__random-games__button'
+        onClick={(event) => { setRandomGames(getRandomGames(filteredGames)); }}
+        >{strings.reroll}</button>
+      <GameItemContainer
+        className='random-games'
+        onGameLaunch={onGameLaunch}
+        findGameId={findGameId}>
+        { gameItems }
+      </GameItemContainer>
+    </div>
   );
 }
 
@@ -66,4 +80,43 @@ export function RandomGames(props: RandomGamesProps) {
 function findGameId(element: EventTarget): string | undefined {
   const game = findElementAncestor(element as Element, target => GameGridItem.isElement(target), true);
   if (game) { return GameGridItem.getId(game); }
+}
+
+/**
+ * Gets a biased selection of random games. Tries to get unique genres for each.
+ * @param games List of games to use
+ * @returns List of randomized games
+ */
+function getRandomGames(games: IGameInfo[]) {
+  const shuffledGames = shuffle(games);
+  if (numberOfGames >= games.length) {
+    // Not enough games to roll for, just return what we have
+    return shuffledGames;
+  } else {
+    let randomGames: IGameInfo[] = [];
+    let index = 0;
+    // Roll upto X times looking for unique genres
+    for (let i = 0; i < numberOfGames; i++) {
+      for (let j = 0; j < rolls; j++) {
+        const game = shuffledGames[index];
+        if (index++ >= shuffledGames.length) { index = 0; }
+        if (!randomGames.find((existingGame) => { return game.genre === existingGame.genre; })) {
+          randomGames.push(game);
+          break;
+        }
+      }
+      // Rolls were all the same genre, just pick the next unique game
+      if (randomGames.length <= i) {
+        while (true) {
+          const game = shuffledGames[index];
+          if (index++ >= shuffledGames.length) { index = 0; }
+          if (!randomGames.find((existingGame) => { game.id === existingGame.id; })) {
+            randomGames.push(game);
+            break;
+          }
+        }
+      }
+    }
+    return randomGames;
+  }
 }

--- a/src/renderer/components/pages/HomePage.tsx
+++ b/src/renderer/components/pages/HomePage.tsx
@@ -175,7 +175,6 @@ export class HomePage extends React.Component<HomePageProps> {
           <SizeProvider width={width} height={height}>
             <div className='home-page__random-games'>
               <div className='home-page__random-games__inner'>
-                <p className='home-page__random-games__title'>{strings.randomPicks}</p>
                 { gamesDoneLoading ? (
                   <RandomGames
                     games={games.collection.games}

--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -65,6 +65,7 @@ const langTemplate = {
     'linuxSupport',
     'linuxSupportLinkText',
     'randomPicks',
+    'reroll'
   ] as const,
   logs: [
     'filters',

--- a/static/window/styles/core.css
+++ b/static/window/styles/core.css
@@ -640,9 +640,15 @@ body {
   margin: 0 auto;
 }
 .home-page__random-games__title {
+  display: inline-block;
   margin: 0.2em 0;
   font-size: 1.2em;
   font-weight: bold;
+}
+.home-page__random-games__button {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding-top: 0.2rem;
 }
 .home-page__random-games__loading {
   display: block;


### PR DESCRIPTION
Adds a re-roll button to the Random Picks section.

Random Games is now a component with a state, stores shuffled games (filtered from props) and selected random games.
Random Games now given a pre-shuffled games list, still performs filtering. 

When selecting random game, looks at the next 10 shuffled games for one with a unique genre from other currently selected random games. If none found, find next unique game. Will loop array is required.