### PR TITLE
Fix execs.json lookup path. (Suggestion by Colin)

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -447,7 +447,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   });
 
   // Load Exec Mappings
-  loadExecMappingsFile(state.config.flashpointPath, content => log({ source: 'Launcher', content }))
+  loadExecMappingsFile(path.join(state.config.flashpointPath, state.config.jsonFolderPath), content => log({ source: 'Launcher', content }))
   .then(data => {
     state.execMappings = data;
   })


### PR DESCRIPTION
This fix allows FP to appropriately read the `execs.json` file from `root/Data` (given `root` is the Flashpoint directory, selected by the user at upgrading time), and not from `root` itself.

Thanks to @colin969 for the suggestion!