### PR TITLE
Mac: Prevent error logs when parsing services.json

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -105,7 +105,9 @@ export namespace GameLauncher {
     }
     // Launch game
     let proc: ChildProcess;
-    switch (opts.game.applicationPath) {
+    const appPath: string = getApplicationPath(opts.game.applicationPath, opts.execMappings, opts.native)
+
+    switch (appPath) {
       case ':flash:': {
         const env = getEnvironment(opts.fpPath);
         if ('ELECTRON_RUN_AS_NODE' in env) {
@@ -120,12 +122,12 @@ export namespace GameLauncher {
         opts.log({
           source: logSource,
           content: `Launch Game "${opts.game.title}" (PID: ${proc.pid}) [\n`+
-                  `    applicationPath: "${opts.game.applicationPath}",\n`+
+                  `    applicationPath: "${appPath}",\n`+
                   `    launchCommand:   "${opts.game.launchCommand}" ]`
         });
       } break;
       default: {
-        const gamePath: string = fixSlashes(path.join(opts.fpPath, getApplicationPath(opts.game.applicationPath, opts.execMappings, opts.native)));
+        const gamePath: string = fixSlashes(path.join(opts.fpPath, appPath));
         const gameArgs: string = opts.game.launchCommand;
         const command: string = createCommand(gamePath, gameArgs);
         proc = exec(command, { env: getEnvironment(opts.fpPath) });
@@ -133,7 +135,7 @@ export namespace GameLauncher {
         opts.log({
           source: logSource,
           content: `Launch Game "${opts.game.title}" (PID: ${proc.pid}) [\n`+
-                  `    applicationPath: "${opts.game.applicationPath}",\n`+
+                  `    applicationPath: "${appPath}",\n`+
                   `    launchCommand:   "${opts.game.launchCommand}",\n`+
                   `    command:         "${command}" ]`
         });

--- a/src/back/ServicesFile.ts
+++ b/src/back/ServicesFile.ts
@@ -37,11 +37,11 @@ export namespace ServicesFile {
       input: data,
       onError: onError && (e => { onError(`Error while parsing Services: ${e.toString()}`); })
     });
-    parsed.redirector = parseBackProcessInfo(parser.prop('redirector'));
-    parsed.fiddler    = parseBackProcessInfo(parser.prop('fiddler'));
-    parsed.server     = parseBackProcessInfo(parser.prop('server'));
-    parser.prop('start').array(item => parsed.start.push(parseBackProcessInfo(item)));
-    parser.prop('stop').array(item  => parsed.stop.push(parseBackProcessInfo(item)));
+    parsed.fiddler    = parseBackProcessInfo(parser.prop('fiddler', true));
+    parsed.redirector = parseBackProcessInfo(parser.prop('redirector', true));
+    parsed.server     = parseBackProcessInfo(parser.prop('server', true));
+    parser.prop('start', true).array(item => parsed.start.push(parseBackProcessInfo(item)));
+    parser.prop('stop', true).array(item  => parsed.stop.push(parseBackProcessInfo(item)));
     return parsed;
   }
 

--- a/src/main/Flash.ts
+++ b/src/main/Flash.ts
@@ -50,10 +50,10 @@ export function flash(init: Init): void {
         extension = '.so';
         break;
       case 'darwin':
-        // @TODO Find out the extension on mac
+        extension = '.plugin'
         break;
       default:
-        console.error(`No plguin file extension is assigned to the current operating system (platform: "${process.platform}").`);
+        console.error(`No plugin file extension is assigned to the current operating system (platform: "${process.platform}").`);
         break;
     }
     app.commandLine.appendSwitch('ppapi-flash-path', path.resolve(state.config.flashpointPath, 'Plugins', state.plugin + extension));

--- a/static/window/flash_index.html
+++ b/static/window/flash_index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <style>


### PR DESCRIPTION
To address the first bullet under https://bluemaxima.org/flashpoint/datahub/Mac_Support#Launcher_Issues

The change in GameLauncher is to have the `execMappings` applied to the `applicationPath` before the switch statement, else the override that I have in execs.json for `:flash:` does not work.