### PR TITLE
refactor: Move app state to redux store

### DIFF
--- a/src/renderer/Util.ts
+++ b/src/renderer/Util.ts
@@ -279,3 +279,13 @@ export function rebuildQuery(opts: RebuildQueryOpts): ViewQuery {
     orderReverse: opts.order.orderReverse,
   };
 }
+
+/** Get the "library route" of a url (returns empty string if URL is not a valid "sub-browse path") */
+export function getBrowseSubPath(urlPath: string): string {
+  if (urlPath.startsWith(Paths.BROWSE)) {
+    let str = urlPath.substr(Paths.BROWSE.length);
+    if (str[0] === '/') { str = str.substring(1); }
+    return str;
+  }
+  return '';
+}

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -419,6 +419,7 @@ export class App extends React.Component<AppProps> {
               this.props.dispatchMain({
                 type: MainActionType.ADD_VIEW_PAGES,
                 library: library,
+                queryId: view.queryId,
                 ranges: res.data.ranges,
               });
             } else {
@@ -430,13 +431,13 @@ export class App extends React.Component<AppProps> {
           this.props.dispatchMain({
             type: MainActionType.REQUEST_VIEW_PAGES,
             library: library,
+            queryId: view.queryId,
             pages: pages,
           });
         }
       }
     }
 
-    //
     for (const l in this.props.main.views) {
       const v = this.props.main.views[l];
       // Check if the meta has not yet been requested
@@ -450,6 +451,7 @@ export class App extends React.Component<AppProps> {
             this.props.dispatchMain({
               type: MainActionType.SET_VIEW_META,
               library: l,
+              queryId: v.queryId,
               keyset: res.data.keyset,
               total: res.data.total,
             });
@@ -460,6 +462,7 @@ export class App extends React.Component<AppProps> {
         this.props.dispatchMain({
           type: MainActionType.REQUEST_VIEW_META,
           library: l,
+          queryId: v.queryId,
         });
       }
     }

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -458,11 +458,8 @@ export class App extends React.Component<AppProps> {
 
         // Flag meta as requested
         this.props.dispatchMain({
-          type: MainActionType.SET_VIEW_STATE,
+          type: MainActionType.REQUEST_VIEW_META,
           library: l,
-          state: {
-            metaState: RequestState.REQUESTED,
-          },
         });
       }
     }
@@ -484,11 +481,9 @@ export class App extends React.Component<AppProps> {
         const view = this.props.main.views[route];
         if (view && view.selectedGameId !== undefined) {
           this.props.dispatchMain({
-            type: MainActionType.SET_VIEW_STATE,
+            type: MainActionType.SET_VIEW_SELECTED_GAME,
             library: route,
-            state: {
-              selectedGameId: undefined,
-            },
+            gameId: undefined,
           });
         }
       } else {
@@ -626,11 +621,9 @@ export class App extends React.Component<AppProps> {
     const view = this.props.main.views[library];
     if (view) {
       this.props.dispatchMain({
-        type: MainActionType.SET_VIEW_STATE,
+        type: MainActionType.SET_VIEW_SELECTED_GAME,
         library: library,
-        state: {
-          selectedGameId: gameId,
-        },
+        gameId: gameId,
       });
     }
   }

--- a/src/renderer/components/Footer.tsx
+++ b/src/renderer/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { WithMainStateProps } from '@renderer/containers/withMainState';
+import { MainActionType } from '@renderer/store/main/enums';
 import { parseBrowsePageLayout, stringifyBrowsePageLayout } from '@shared/BrowsePageLayout';
 import { LangContainer } from '@shared/lang';
 import { getLibraryItemTitle } from '@shared/library/util';
@@ -111,8 +112,8 @@ export class Footer extends React.Component<FooterProps> {
   }
 
   onNewGameClick = () => {
-    // @TODO Replace this with an proper action (it should both change the location and state of the current or most recent view)
-    this.props.setMainState({ wasNewGameClicked: true });
+    // @TODO Replace this with a proper action (it should both change the location and state of the current or most recent view)
+    this.props.dispatchMain({ type: MainActionType.CLICK_NEW_GAME });
   }
 
   onScaleSliderChange = (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/src/renderer/components/GameGrid.tsx
+++ b/src/renderer/components/GameGrid.tsx
@@ -1,6 +1,5 @@
 import { BackOut, ImageChangeData, WrappedResponse } from '@shared/back/types';
 import { LOGOS, VIEW_PAGE_SIZE } from '@shared/constants';
-import { GameOrderBy, GameOrderReverse } from '@shared/order/interfaces';
 import * as React from 'react';
 import { ArrowKeyStepper, AutoSizer, ScrollIndices } from 'react-virtualized';
 import { Grid, GridCellProps, RenderedSection } from 'react-virtualized/dist/es/Grid';
@@ -44,9 +43,6 @@ export type GameGridProps = {
   /** Called when the user stops dragging a game (when they release it). */
   onGameDragEnd?: (event: React.DragEvent, gameId: string) => void;
   updateView: UpdateView;
-  // React-Virtualized pass-through props (their values are not used for anything other than updating the grid when changed)
-  orderBy?: GameOrderBy;
-  orderReverse?: GameOrderReverse;
   /** Function for getting a reference to grid element. Called whenever the reference could change. */
   gridRef?: RefFunc<HTMLDivElement>;
 };
@@ -165,8 +161,6 @@ export class GameGrid extends React.Component<GameGridProps> {
                       onSectionRendered={(params: RenderedSection) => this.onSectionRendered(params, columns, onSectionRendered)}
                       // Pass-through props (they have no direct effect on the grid)
                       // (If any property is changed the grid is re-rendered, even these)
-                      pass_orderBy={this.props.orderBy}
-                      pass_orderReverse={this.props.orderReverse}
                       pass_currentGamesCount={this.currentGamesCount} />
                   );
                 }}

--- a/src/renderer/components/GameList.tsx
+++ b/src/renderer/components/GameList.tsx
@@ -1,5 +1,4 @@
 import { VIEW_PAGE_SIZE } from '@shared/constants';
-import { GameOrderBy, GameOrderReverse } from '@shared/order/interfaces';
 import * as React from 'react';
 import { ArrowKeyStepper, AutoSizer, List, ListRowProps, ScrollIndices } from 'react-virtualized';
 import { UpdateView, ViewGameSet } from '../interfaces';
@@ -36,9 +35,6 @@ export type GameListProps = {
   /** Called when the user stops dragging a game (when they release it). */
   onGameDragEnd: (event: React.DragEvent, gameId: string) => void;
   updateView: UpdateView;
-  // React-Virtualized pass-through props (their values are not used for anything other than updating the grid when changed)
-  orderBy?: GameOrderBy;
-  orderReverse?: GameOrderReverse;
   /** Function for getting a reference to grid element. Called whenever the reference could change. */
   listRef?: RefFunc<HTMLDivElement>;
 };
@@ -134,8 +130,6 @@ export class GameList extends React.Component<GameListProps> {
                       onSectionRendered={onSectionRendered}
                       // Pass-through props (they have no direct effect on the list)
                       // (If any property is changed the list is re-rendered, even these)
-                      pass_orderBy={this.props.orderBy}
-                      pass_orderReverse={this.props.orderReverse}
                       pass_gamesChanged={gamesChanged} />
                   )}
                 </ArrowKeyStepper>

--- a/src/renderer/components/Header.tsx
+++ b/src/renderer/components/Header.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
-import { Link, RouteComponentProps } from 'react-router-dom';
 import { LangContainer } from '@shared/lang';
 import { getLibraryItemTitle } from '@shared/library/util';
+import { GameOrderBy, GameOrderReverse } from '@shared/order/interfaces';
+import * as React from 'react';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { WithPreferencesProps } from '../containers/withPreferences';
 import { Paths } from '../Paths';
 import { SearchQuery } from '../store/search';
@@ -13,8 +14,10 @@ import { OpenIcon } from './OpenIcon';
 type OwnProps = {
   /** The most recent search query. */
   searchQuery: SearchQuery;
-  /** The current parameters for ordering games. */
-  order: GameOrderChangeEvent;
+  /** Current value of the "order by" drop down. */
+  orderBy: GameOrderBy;
+  /** Current value of the "order reverse" drop down. */
+  orderReverse: GameOrderReverse;
   /** Array of library routes */
   libraries: string[];
   /** Called when a search is made. */
@@ -152,8 +155,8 @@ export class Header extends React.Component<HeaderProps, HeaderState> {
           <div>
             <GameOrder
               onChange={onOrderChange}
-              orderBy={this.props.order.orderBy}
-              orderReverse={this.props.order.orderReverse} />
+              orderBy={this.props.orderBy}
+              orderReverse={this.props.orderReverse} />
           </div>
         </div>
         {/* Right-most portion */}

--- a/src/renderer/components/RandomGames.tsx
+++ b/src/renderer/components/RandomGames.tsx
@@ -21,6 +21,10 @@ export function RandomGames(props: RandomGamesProps) {
     props.onLaunchGame(gameId);
   }, [props.onLaunchGame]);
 
+  const onRerollPicks = React.useCallback(() => {
+    props.rollRandomGames();
+  }, [props.rollRandomGames]);
+
   const gameItems = React.useMemo(() => (
     /* Games is a long queue, only render front */
     props.games.slice(0, 5).map(game => (
@@ -47,7 +51,7 @@ export function RandomGames(props: RandomGamesProps) {
         </GameItemContainer>
         <SimpleButton
           value={strings.home.rerollPicks}
-          onClick={props.rollRandomGames} />
+          onClick={onRerollPicks} />
       </ul>
     </div>
   );

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -23,7 +23,6 @@ import { queueOne } from '../../util/queue';
 import { uuid } from '../../util/uuid';
 import { GameGrid } from '../GameGrid';
 import { GameList } from '../GameList';
-import { GameOrderChangeEvent } from '../GameOrder';
 import { InputElement } from '../InputField';
 import { ResizableSidebar, SidebarResizeEvent } from '../ResizableSidebar';
 
@@ -44,8 +43,6 @@ type OwnProps = {
 
   /** Most recent search query. */
   search: SearchQuery;
-  /** Current parameters for ordering games. */
-  order?: GameOrderChangeEvent;
   /** Scale of the games. */
   gameScale: number;
   /** Layout of the games. */
@@ -176,7 +173,6 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
     const strings = this.context;
     const { games, selectedGameId, selectedPlaylistId } = this.props;
     const { draggedGameId } = this.state;
-    const order = this.props.order || BrowsePage.defaultOrder;
     // Render
     return (
       <div
@@ -234,8 +230,6 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
                   onContextMenu={this.onGameContextMenuMemo(strings)}
                   onGameDragStart={this.onGameDragStart}
                   onGameDragEnd={this.onGameDragEnd}
-                  orderBy={order.orderBy}
-                  orderReverse={order.orderReverse}
                   cellWidth={width}
                   cellHeight={height}
                   gridRef={this.gameGridOrListRefFunc} />
@@ -255,8 +249,6 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
                   onGameDragStart={this.onGameDragStart}
                   onGameDragEnd={this.onGameDragEnd}
                   updateView={this.props.updateView}
-                  orderBy={order.orderBy}
-                  orderReverse={order.orderReverse}
                   rowHeight={height}
                   listRef={this.gameGridOrListRefFunc} />
               );
@@ -897,11 +889,6 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
 
   gameGridOrListRefFunc = (ref: HTMLDivElement | null): void => {
     this.gameGridOrListRef = ref;
-  }
-
-  static defaultOrder: Readonly<GameOrderChangeEvent> = {
-    orderBy: 'title',
-    orderReverse: 'ASC',
   }
 
   static contextType = LangContext;

--- a/src/renderer/components/pages/BrowsePage.tsx
+++ b/src/renderer/components/pages/BrowsePage.tsx
@@ -43,10 +43,6 @@ type OwnProps = {
 
   /** Most recent search query. */
   search: SearchQuery;
-  /** Scale of the games. */
-  gameScale: number;
-  /** Layout of the games. */
-  gameLayout: BrowsePageLayout;
   /** Currently selected game (if any). */
   selectedGameId?: string;
   /** Currently selected playlist (if any). */
@@ -213,9 +209,9 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
           className='game-browser__center'
           onKeyDown={this.onCenterKeyDown}>
           {(() => {
-            if (this.props.gameLayout === BrowsePageLayout.grid) {
+            if (this.props.preferencesData.browsePageLayout === BrowsePageLayout.grid) {
               // (These are kind of "magic numbers" and the CSS styles are designed to fit with them)
-              const height: number = calcScale(350, this.props.gameScale);
+              const height: number = calcScale(350, this.props.preferencesData.browsePageGameScale);
               const width: number = (height * 0.666) | 0;
               return (
                 <GameGrid
@@ -235,7 +231,7 @@ export class BrowsePage extends React.Component<BrowsePageProps, BrowsePageState
                   gridRef={this.gameGridOrListRefFunc} />
               );
             } else {
-              const height: number = calcScale(30, this.props.gameScale);
+              const height: number = calcScale(30, this.props.preferencesData.browsePageGameScale);
               return (
                 <GameList
                   games={games}

--- a/src/renderer/components/pages/TagCategoriesPage.tsx
+++ b/src/renderer/components/pages/TagCategoriesPage.tsx
@@ -13,9 +13,7 @@ import { SimpleButton } from '../SimpleButton';
 import { TagCategoriesList } from '../TagCategoriesList';
 import { TagListItem } from '../TagListItem';
 
-
 type OwnProps = {
-  tagScale: number;
 }
 
 export type TagCategoriesPageProps = OwnProps & WithTagCategoriesProps & WithPreferencesProps;
@@ -46,7 +44,7 @@ export class TagCategoriesPage extends React.Component<TagCategoriesPageProps, T
   }
 
   render() {
-    const rowHeight = calcScale(40, this.props.tagScale);
+    const rowHeight = calcScale(40, this.props.preferencesData.browsePageGameScale);
     const strings = this.context.tags;
 
     return (

--- a/src/renderer/components/pages/TagsPage.tsx
+++ b/src/renderer/components/pages/TagsPage.tsx
@@ -11,7 +11,6 @@ import { TagList } from '../TagList';
 import { TagListItem } from '../TagListItem';
 
 type OwnProps = {
-  tagScale: number;
 }
 
 export type TagsPageProps = OwnProps & WithTagCategoriesProps & WithPreferencesProps;
@@ -54,7 +53,7 @@ export class TagsPage extends React.Component<TagsPageProps, TagsPageState> {
   }
 
   render() {
-    const rowHeight = calcScale(40, this.props.tagScale);
+    const rowHeight = calcScale(40, this.props.preferencesData.browsePageGameScale);
 
     return (
       <div className='tags-page simple-scroll'>

--- a/src/renderer/containers/ConnectedApp.ts
+++ b/src/renderer/containers/ConnectedApp.ts
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
 import { App } from '../app';
 import { ApplicationState } from '../store';
+import { withMainState } from './withMainState';
 import { withPreferences } from './withPreferences';
 import { withTagCategories } from './withTagCategories';
 
@@ -14,7 +15,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => bindActionCreators({
   // ...
 }, dispatch);
 
-export default withRouter(withTagCategories(withPreferences(connect(
+export default withRouter(withMainState(withTagCategories(withPreferences(connect(
   mapStateToProps,
   mapDispatchToProps
-)(App))));
+)(App)))));

--- a/src/renderer/containers/ConnectedFooter.ts
+++ b/src/renderer/containers/ConnectedFooter.ts
@@ -1,4 +1,6 @@
+import { withRouter } from 'react-router-dom';
 import { Footer } from '../components/Footer';
+import { withMainState } from './withMainState';
 import { withPreferences } from './withPreferences';
 
-export const ConnectedFooter = withPreferences(Footer);
+export const ConnectedFooter = withRouter(withMainState(withPreferences(Footer)));

--- a/src/renderer/containers/withMainState.ts
+++ b/src/renderer/containers/withMainState.ts
@@ -1,0 +1,28 @@
+import { ApplicationState } from '@renderer/store';
+import { MainActionType } from '@renderer/store/main/enums';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { MainAction, MainState } from '../store/main/types';
+
+export type WithMainStateProps = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>
+
+const mapStateToProps = (state: ApplicationState) => ({
+  main: state.main,
+});
+
+function mapDispatchToProps(dispatch: Dispatch<MainAction>) {
+  return {
+    dispatchMain: dispatch,
+    setMainState: <K extends keyof MainState>(state: Pick<MainState, K> | MainState): MainAction => dispatch({
+      type: MainActionType.SET_STATE,
+      payload: state,
+    }),
+  };
+}
+
+export const withMainState = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  null,
+  { getDisplayName: name => 'withMainState('+name+')' }
+);

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -3,7 +3,6 @@ import { createMemoryHistory } from 'history';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { GameOrderChangeEvent } from './components/GameOrder';
 import configureStore from './configureStore';
 import ConnectedApp from './containers/ConnectedApp';
 import { ContextReducerProvider } from './context-reducer/ContextReducerProvider';
@@ -53,11 +52,6 @@ import { rebuildQuery } from './Util';
 function createInitialMainState(): MainState {
   const preferencesData = window.Shared.preferences.data;
 
-  const order: GameOrderChangeEvent = {
-    orderBy: preferencesData.gamesOrderBy,
-    orderReverse: preferencesData.gamesOrder
-  };
-
   // Prepare libraries
   const libraries = window.Shared.initialLibraries.sort();
   const serverNames = window.Shared.initialServerNames.sort();
@@ -70,7 +64,10 @@ function createInitialMainState(): MainState {
         extreme: preferencesData.browsePageShowExtreme,
         library: library,
         playlistId: undefined,
-        order: order,
+        order: {
+          orderBy: preferencesData.gamesOrderBy,
+          orderReverse: preferencesData.gamesOrder
+        },
       }),
       pageState: {},
       meta: undefined,
@@ -79,7 +76,6 @@ function createInitialMainState(): MainState {
       queryId: 0,
       isDirty: false,
       total: undefined,
-      selectedPlaylistId: undefined,
       selectedGameId: undefined,
       lastStart: 0,
       lastCount: 0,
@@ -118,8 +114,6 @@ function createInitialMainState(): MainState {
     stopRender: false,
     creditsData: undefined,
     creditsDoneLoading: false,
-    gameScale: preferencesData.browsePageGameScale,
-    gameLayout: preferencesData.browsePageLayout,
     lang: window.Shared.initialLang,
     langList: window.Shared.initialLangList,
     wasNewGameClicked: false,

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -107,6 +107,7 @@ function createInitialMainState(): MainState {
     gamesTotal: -1,
     randomGames: [],
     requestingRandomGames: false,
+    shiftRandomGames: false,
     localeCode: window.Shared.initialLocaleCode,
     upgrades: [],
     gamesDoneLoading: false,

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -2,7 +2,6 @@ import { Game } from '@database/entity/Game';
 import { Playlist } from '@database/entity/Playlist';
 import { PlaylistGame } from '@database/entity/PlaylistGame';
 import { ViewGame } from '@shared/back/types';
-import { BrowsePageLayout } from '@shared/BrowsePageLayout';
 import { GamePropSuggestions } from '@shared/interfaces';
 import { LangContainer, LangFile } from '@shared/lang';
 import { Theme } from '@shared/ThemeFile';
@@ -17,8 +16,8 @@ import { ConnectedConfigPage, ConnectedConfigPageProps } from './containers/Conn
 import { ConnectedCuratePage, ConnectedCuratePageProps } from './containers/ConnectedCuratePage';
 import { ConnectedHomePage, ConnectedHomePageProps } from './containers/ConnectedHomePage';
 import { ConnectedLogsPage } from './containers/ConnectedLogsPage';
-import { ConnectedTagCategoriesPage, ConnectedTagCategoriesPageProps } from './containers/ConnectedTagCategoriesPage';
-import { ConnectedTagsPage, ConnectedTagsPageProps } from './containers/ConnectedTagsPage';
+import { ConnectedTagCategoriesPage } from './containers/ConnectedTagCategoriesPage';
+import { ConnectedTagsPage } from './containers/ConnectedTagsPage';
 import { CreditsData } from './credits/types';
 import { UpdateView, ViewGameSet } from './interfaces';
 import { Paths } from './Paths';
@@ -49,8 +48,6 @@ export type AppRouterProps = {
   upgrades: UpgradeStage[];
   creditsData?: CreditsData;
   creditsDoneLoading: boolean;
-  gameScale: number;
-  gameLayout: BrowsePageLayout;
   selectedGameId?: string;
   selectedPlaylistId?: string;
   onSelectGame: (gameId?: string) => void;
@@ -91,8 +88,6 @@ export class AppRouter extends React.Component<AppRouterProps> {
       onDeleteGame: this.props.onDeleteGame,
       onQuickSearch: this.props.onQuickSearch,
       onOpenExportMetaEdit: this.props.onOpenExportMetaEdit,
-      gameScale: this.props.gameScale,
-      gameLayout: this.props.gameLayout,
       selectedGameId: this.props.selectedGameId,
       selectedPlaylistId: this.props.selectedPlaylistId,
       onSelectGame: this.props.onSelectGame,
@@ -101,12 +96,6 @@ export class AppRouter extends React.Component<AppRouterProps> {
       onSelectPlaylist: this.props.onSelectPlaylist,
       wasNewGameClicked: this.props.wasNewGameClicked,
       gameLibrary: this.props.gameLibrary,
-    };
-    const tagsProps: ConnectedTagsPageProps = {
-      tagScale: this.props.gameScale
-    };
-    const tagCategoriesProps: ConnectedTagCategoriesPageProps = {
-      tagScale: this.props.gameScale
     };
     const configProps: ConnectedConfigPageProps = {
       themeList: this.props.themeList,
@@ -143,12 +132,10 @@ export class AppRouter extends React.Component<AppRouterProps> {
           { ...browseProps } />
         <PropsRoute
           path={Paths.TAGS}
-          component={ConnectedTagsPage}
-          { ...tagsProps } />
+          component={ConnectedTagsPage} />
         <PropsRoute
           path={Paths.CATEGORIES}
-          component={ConnectedTagCategoriesPage}
-          { ...tagCategoriesProps } />
+          component={ConnectedTagCategoriesPage} />
         <PropsRoute
           path={Paths.LOGS}
           component={ConnectedLogsPage} />

--- a/src/renderer/router.tsx
+++ b/src/renderer/router.tsx
@@ -1,6 +1,7 @@
 import { Game } from '@database/entity/Game';
 import { Playlist } from '@database/entity/Playlist';
 import { PlaylistGame } from '@database/entity/PlaylistGame';
+import { ViewGame } from '@shared/back/types';
 import { BrowsePageLayout } from '@shared/BrowsePageLayout';
 import { GamePropSuggestions } from '@shared/interfaces';
 import { LangContainer, LangFile } from '@shared/lang';
@@ -8,7 +9,6 @@ import { Theme } from '@shared/ThemeFile';
 import { AppUpdater, UpdateInfo } from 'electron-updater';
 import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
-import { GameOrderChangeEvent } from './components/GameOrder';
 import { AboutPage, AboutPageProps } from './components/pages/AboutPage';
 import { DeveloperPage, DeveloperPageProps } from './components/pages/DeveloperPage';
 import { NotFoundPage } from './components/pages/NotFoundPage';
@@ -23,7 +23,6 @@ import { CreditsData } from './credits/types';
 import { UpdateView, ViewGameSet } from './interfaces';
 import { Paths } from './Paths';
 import { UpgradeStage } from './upgrade/types';
-import { ViewGame } from '@shared/back/types';
 
 export type AppRouterProps = {
   games: ViewGameSet;
@@ -50,7 +49,6 @@ export type AppRouterProps = {
   upgrades: UpgradeStage[];
   creditsData?: CreditsData;
   creditsDoneLoading: boolean;
-  order?: GameOrderChangeEvent;
   gameScale: number;
   gameLayout: BrowsePageLayout;
   selectedGameId?: string;
@@ -93,7 +91,6 @@ export class AppRouter extends React.Component<AppRouterProps> {
       onDeleteGame: this.props.onDeleteGame,
       onQuickSearch: this.props.onQuickSearch,
       onOpenExportMetaEdit: this.props.onOpenExportMetaEdit,
-      order: this.props.order,
       gameScale: this.props.gameScale,
       gameLayout: this.props.gameLayout,
       selectedGameId: this.props.selectedGameId,

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1,20 +1,24 @@
+import { TagCategory } from '@database/entity/TagCategory';
 import { connectRouter, RouterState } from 'connected-react-router';
 import { History } from 'history';
 import { combineReducers } from 'redux';
+import { mainStateReducer } from './main/reducer';
+import { MainState } from './main/types';
 import { searchReducer, SearchState } from './search';
 import { tagCategoriesReducer } from './tagCategories';
-import { TagCategory } from '@database/entity/TagCategory';
 
 // The top-level state object
 export interface ApplicationState {
   router: RouterState;
   search: SearchState;
   tagCategories: TagCategory[];
+  main: MainState;
 }
 
 // Top-level reducer
 export const createRootReducer = (history: History) => combineReducers<ApplicationState>({
   router: connectRouter(history),
   search: searchReducer,
-  tagCategories: tagCategoriesReducer
+  tagCategories: tagCategoriesReducer,
+  main: mainStateReducer,
 });

--- a/src/renderer/store/main/enums.ts
+++ b/src/renderer/store/main/enums.ts
@@ -19,6 +19,36 @@ export enum MainActionType {
   SET_ORDER = '@@main/SET_ORDER',
   /** Set the credits data (or at least flag it as done loading it). */
   SET_CREDITS = '@@main/SET_CREDITS',
+  /** Stop rendering. */
+  STOP_RENDER = '@@main/STOP_RENDER',
+  /** Open the meta exporter overlay. */
+  OPEN_META_EXPORTER = '@@main/OPEN_META_EXPORTER',
+  /** Close the meta exporter overlay. */
+  CLOSE_META_EXPORTER = '@@main/CLOSE_META_EXPORTER',
+  /** Flag things as loaded. */
+  ADD_LOADED = '@@main/ADD_LOADED',
+  /** Set the total number of games. */
+  SET_GAMES_TOTAL = '@@main/SET_GAMES_TOTAL',
+  /** Set the suggestions. */
+  SET_SUGGESTIONS = '@@main/SET_SUGGESTIONS',
+  /** Set the locale. */
+  SET_LOCALE = '@@main/SET_LOCALE',
+  /** Set the language. */
+  SET_LANGUAGE = '@@main/SET_LANGUAGE',
+  /** Set the language list. */
+  SET_LANGUAGE_LIST = '@@main/SET_LANGUAGE_LIST',
+  /** Set the theme list. */
+  SET_THEME_LIST = '@@main/SET_THEME_LIST',
+  /** Set the playlists. */
+  SET_PLAYLISTS = '@@main/SET_PLAYLISTS',
+  /** Set the upgrades. */
+  SET_UPGRADES = '@@main/SET_UPGRADES',
+  /** Set the update info. */
+  SET_UPDATE_INFO = '@@main/SET_UPDATE_INFO',
+  /** Create a new game. This is an ancient and wonky system! */
+  CLICK_NEW_GAME = '@@main/CLICK_NEW_GAME',
+  /** Perform this action AFTER creating a new game (using CLICK_NEW_GAME)! */
+  CLICK_NEW_GAME_END = '@@main/CLICK_NEW_GAME_END',
 }
 
 export enum RequestState {

--- a/src/renderer/store/main/enums.ts
+++ b/src/renderer/store/main/enums.ts
@@ -17,6 +17,8 @@ export enum MainActionType {
   ADD_VIEW_PAGES = '@@main/ADD_VIEW_PAGES',
   /** Set the order. This is a "central order" used by all views. */
   SET_ORDER = '@@main/SET_ORDER',
+  /** Set the credits data (or at least flag it as done loading it). */
+  SET_CREDITS = '@@main/SET_CREDITS',
 }
 
 export enum RequestState {

--- a/src/renderer/store/main/enums.ts
+++ b/src/renderer/store/main/enums.ts
@@ -1,0 +1,29 @@
+export enum MainActionType {
+  // @TODO Temporary (should be separated into individual actions)
+  /** Drop in replacement for "this.setState". */
+  SET_STATE = '@@main/SET_STATE',
+  /** Drop in replacement for "this.setState" when only editing the state of a single view. */
+  SET_VIEW_STATE = '@@main/SET_VIEW_STATE',
+  // Normal actions
+  /** Set the query of a view. */
+  SET_VIEW_QUERY = '@@main/SET_VIEW_QUERY',
+  /** Set the current "boundries" of a view. These describe the range of currently visible pages. */
+  SET_VIEW_BOUNDRIES = '@@main/SET_VIEW_BOUNDRIES',
+  /** Set the meta of a view. */
+  SET_VIEW_META = '@@main/SET_VIEW_META',
+  /** Flag pages of a view as requested. This is to prevent the same pages from being requested multiple times. */
+  REQUEST_VIEW_PAGES = '@@main/REQUEST_VIEW_PAGES',
+  /** Add pages to a view. */
+  ADD_VIEW_PAGES = '@@main/ADD_VIEW_PAGES',
+  /** Set the order. This is a "central order" used by all views. */
+  SET_ORDER = '@@main/SET_ORDER',
+}
+
+export enum RequestState {
+  /** Request is waiting to be made. */
+  WAITING,
+  /** Reqest has been made. Waiting for the response to be received. */
+  REQUESTED,
+  /** Response has been received. */
+  RECEIVED,
+}

--- a/src/renderer/store/main/enums.ts
+++ b/src/renderer/store/main/enums.ts
@@ -49,6 +49,14 @@ export enum MainActionType {
   CLICK_NEW_GAME = '@@main/CLICK_NEW_GAME',
   /** Perform this action AFTER creating a new game (using CLICK_NEW_GAME)! */
   CLICK_NEW_GAME_END = '@@main/CLICK_NEW_GAME_END',
+  /** Remove the currently displayed random games and shift in new games from the queue. */
+  SHIFT_RANDOM_GAMES = '@@main/SHIFT_RANDOM_GAMES',
+  /** Flag random games as being requested. */
+  REQUEST_RANDOM_GAMES = '@@main/REQUEST_RANDOM_GAMES',
+  /** Add random games to the end of the queue and unset the flag for requesting random games. */
+  RESPONSE_RANDOM_GAMES = '@@main/RESPONSE_RANDOM_GAMES',
+  /** Remove all queued random games (the currently displayed games are NOT removed). */
+  CLEAR_RANDOM_GAMES = '@@main/CLEAR_RANDOM_GAMES',
 }
 
 export enum RequestState {

--- a/src/renderer/store/main/enums.ts
+++ b/src/renderer/store/main/enums.ts
@@ -2,21 +2,21 @@ export enum MainActionType {
   // @TODO Temporary (should be separated into individual actions)
   /** Drop in replacement for "this.setState". */
   SET_STATE = '@@main/SET_STATE',
-  /** Drop in replacement for "this.setState" when only editing the state of a single view. */
-  SET_VIEW_STATE = '@@main/SET_VIEW_STATE',
   // Normal actions
   /** Set the query of a view. */
   SET_VIEW_QUERY = '@@main/SET_VIEW_QUERY',
   /** Set the current "boundries" of a view. These describe the range of currently visible pages. */
   SET_VIEW_BOUNDRIES = '@@main/SET_VIEW_BOUNDRIES',
-  /** Set the meta of a view. */
+  /** Flag the request meta as requested. */
+  REQUEST_VIEW_META = '@@main/SET_VIEW_REQUESTED',
+  /** Set the meta of a view and flag the meta as received. */
   SET_VIEW_META = '@@main/SET_VIEW_META',
   /** Flag pages of a view as requested. This is to prevent the same pages from being requested multiple times. */
   REQUEST_VIEW_PAGES = '@@main/REQUEST_VIEW_PAGES',
   /** Add pages to a view. */
   ADD_VIEW_PAGES = '@@main/ADD_VIEW_PAGES',
-  /** Set the order. This is a "central order" used by all views. */
-  SET_ORDER = '@@main/SET_ORDER',
+  /** Set the selected game of a view. */
+  SET_VIEW_SELECTED_GAME = '@@main/SET_VIEW_SELECTED_GAME',
   /** Set the credits data (or at least flag it as done loading it). */
   SET_CREDITS = '@@main/SET_CREDITS',
   /** Stop rendering. */

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -39,7 +39,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
                 orderReverse: action.orderReverse,
               },
             }),
-            queryId: (view.queryId + 1) % 0x80000000,
+            queryId: (view.queryId + 1) % 0x80000000, // 32 bit signed integer
             metaState: RequestState.WAITING,
           },
         },
@@ -91,7 +91,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
     case MainActionType.REQUEST_VIEW_META: {
       const view = state.views[action.library];
 
-      if (!view) { return state; }
+      if (!view || action.queryId !== view.queryId) { return state; }
 
       return {
         ...state,
@@ -108,7 +108,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
     case MainActionType.SET_VIEW_META: {
       const view = state.views[action.library];
 
-      if (!view) { return state; }
+      if (!view || action.queryId !== view.queryId) { return state; }
 
       return {
         ...state,
@@ -137,7 +137,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
     case MainActionType.REQUEST_VIEW_PAGES: {
       const view = state.views[action.library];
 
-      if (!view) { return state; }
+      if (!view || action.queryId !== view.queryId) { return state; }
 
       let newPageState: ViewPageStates | undefined;
 
@@ -166,7 +166,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
     case MainActionType.ADD_VIEW_PAGES: {
       const view = state.views[action.library];
 
-      if (!view || !view.meta) { return state; }
+      if (!view || !view.meta || action.queryId !== view.queryId) { return state; }
 
       const newGames = (view.isDirty) ? {} : { ...view.games };
 

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -1,0 +1,228 @@
+import { rebuildQuery } from '@renderer/Util';
+import { createLangContainer } from '@shared/lang';
+import { MainActionType, RequestState } from './enums';
+import { MainAction, MainState, View, ViewPageStates } from './types';
+
+export function mainStateReducer(state: MainState = createInitialState(), action: MainAction): MainState {
+  switch (action.type) {
+    default:
+      return state;
+
+    case MainActionType.SET_STATE:
+      return {
+        ...state,
+        ...action.payload,
+      };
+
+    case MainActionType.SET_VIEW_QUERY: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            query: rebuildQuery({
+              text: action.searchText,
+              extreme: action.showExtreme,
+              library: action.library,
+              playlistId: view.selectedPlaylistId,
+              order: {
+                orderBy: action.orderBy,
+                orderReverse: action.orderReverse,
+              },
+            }),
+            queryId: (view.queryId + 1) % 0x80000000,
+            metaState: RequestState.WAITING,
+          },
+        },
+      };
+    }
+
+    case MainActionType.SET_VIEW_BOUNDRIES: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      const sameBoundries = (view.lastStart === action.start && view.lastCount === action.count);
+
+      if (!view.isDirty && sameBoundries) { return state; } // Optimization, this should never be able to return any pages not already flagged
+
+      // Flag unseen pages that have entered the boundries
+
+      let newPageState: ViewPageStates | undefined;
+
+      const end = action.start + action.count;
+      for (let i = action.start; i < end; i++) {
+        if (!(i in view.pageState)) {
+          if (!newPageState) { newPageState = { ...view.pageState }; }
+          newPageState[i] = RequestState.WAITING;
+        }
+      }
+
+      if (!newPageState && sameBoundries) { return state; } // Nothing has changed
+
+      const newView: View = {
+        ...view,
+        lastStart: action.start,
+        lastCount: action.count,
+      };
+
+      if (newPageState) {
+        newView.pageState = newPageState;
+      }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: newView,
+        },
+      };
+    }
+
+    case MainActionType.SET_VIEW_STATE: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            ...action.state,
+          },
+        },
+      };
+    }
+
+    case MainActionType.SET_VIEW_META: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            meta: {
+              pageKeyset: action.keyset,
+              total: action.total,
+            },
+            //
+            metaState: RequestState.RECEIVED,
+            // Dirty games
+            isDirty: true,
+            pageState: {},
+            // Update total (for the first reponse only)
+            total: (view.total === undefined)
+              ? action.total
+              : view.total,
+          },
+        },
+      };
+    }
+
+    case MainActionType.REQUEST_VIEW_PAGES: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      let newPageState: ViewPageStates | undefined;
+
+      for (const pageIndex of action.pages) {
+        const pageState = view.pageState[pageIndex];
+        if (pageState === RequestState.WAITING || pageState === undefined) {
+          if (!newPageState) { newPageState = { ...view.pageState }; }
+          newPageState[pageIndex] = RequestState.REQUESTED;
+        }
+      }
+
+      if (!newPageState) { return state; }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            pageState: newPageState,
+          },
+        },
+      };
+    }
+
+    case MainActionType.ADD_VIEW_PAGES: {
+      const view = state.views[action.library];
+
+      if (!view || !view.meta) { return state; }
+
+      const newGames = (view.isDirty) ? {} : { ...view.games };
+
+      for (const range of action.ranges) {
+        const length = Math.min(range.games.length, view.meta.total);
+        for (let i = 0; i < length; i++) {
+          newGames[range.start + i] = range.games[i];
+        }
+      }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            games: newGames,
+            isDirty: false,
+            total: view.meta.total, // Update dirty total
+          },
+        },
+      };
+    }
+  }
+}
+
+function createInitialState(): MainState {
+  return {
+    views: {},
+    libraries: [],
+    serverNames: [],
+    mad4fpEnabled: false,
+    playlists: [],
+    playlistIconCache: {},
+    suggestions: {},
+    appPaths: {},
+    platforms: {},
+    loaded: {
+      0: false,
+      1: false,
+      2: false,
+    },
+    themeList: [],
+    gamesTotal: -1,
+    randomGames: [],
+    requestingRandomGames: false,
+    localeCode: 'n',
+    upgrades: [],
+    gamesDoneLoading: false,
+    upgradesDoneLoading: false,
+    stopRender: false,
+    creditsData: undefined,
+    creditsDoneLoading: false,
+    gameScale: 1,
+    gameLayout: 1,
+    lang: createLangContainer(),
+    langList: [],
+    wasNewGameClicked: false,
+    updateInfo: undefined,
+    metaEditExporterOpen: false,
+    metaEditExporterGameId: '',
+  };
+}

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -19,6 +19,10 @@ export function mainStateReducer(state: MainState = createInitialState(), action
 
       if (!view) { return state; }
 
+      const playlistId = (action.playlistId !== null)
+        ? action.playlistId
+        : view.query.filter.playlistId;
+
       return {
         ...state,
         views: {
@@ -29,7 +33,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
               text: action.searchText,
               extreme: action.showExtreme,
               library: action.library,
-              playlistId: view.selectedPlaylistId,
+              playlistId: playlistId,
               order: {
                 orderBy: action.orderBy,
                 orderReverse: action.orderReverse,
@@ -186,6 +190,14 @@ export function mainStateReducer(state: MainState = createInitialState(), action
         },
       };
     }
+
+    case MainActionType.SET_CREDITS: {
+      return {
+        ...state,
+        creditsDoneLoading: true,
+        creditsData: action.creditsData,
+      };
+    }
   }
 }
 
@@ -216,8 +228,6 @@ function createInitialState(): MainState {
     stopRender: false,
     creditsData: undefined,
     creditsDoneLoading: false,
-    gameScale: 1,
-    gameLayout: 1,
     lang: createLangContainer(),
     langList: [],
     wasNewGameClicked: false,

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -88,7 +88,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
       };
     }
 
-    case MainActionType.SET_VIEW_STATE: {
+    case MainActionType.REQUEST_VIEW_META: {
       const view = state.views[action.library];
 
       if (!view) { return state; }
@@ -99,7 +99,7 @@ export function mainStateReducer(state: MainState = createInitialState(), action
           ...state.views,
           [action.library]: {
             ...view,
-            ...action.state,
+            metaState: RequestState.REQUESTED,
           },
         },
       };
@@ -186,6 +186,23 @@ export function mainStateReducer(state: MainState = createInitialState(), action
             games: newGames,
             isDirty: false,
             total: view.meta.total, // Update dirty total
+          },
+        },
+      };
+    }
+
+    case MainActionType.SET_VIEW_SELECTED_GAME: {
+      const view = state.views[action.library];
+
+      if (!view) { return state; }
+
+      return {
+        ...state,
+        views: {
+          ...state.views,
+          [action.library]: {
+            ...view,
+            selectedGameId: action.gameId,
           },
         },
       };

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -198,6 +198,120 @@ export function mainStateReducer(state: MainState = createInitialState(), action
         creditsData: action.creditsData,
       };
     }
+
+    case MainActionType.STOP_RENDER: {
+      return {
+        ...state,
+        stopRender: true,
+      };
+    }
+
+    case MainActionType.OPEN_META_EXPORTER: {
+      return {
+        ...state,
+        metaEditExporterOpen: true,
+        metaEditExporterGameId: action.gameId,
+      };
+    }
+
+    case MainActionType.CLOSE_META_EXPORTER: {
+      return {
+        ...state,
+        metaEditExporterOpen: false,
+      };
+    }
+
+    case MainActionType.ADD_LOADED: {
+      const nextLoaded = { ...state.loaded };
+
+      for (const key of action.loaded) {
+        nextLoaded[key] = true;
+      }
+
+      return {
+        ...state,
+        loaded: nextLoaded,
+      };
+    }
+
+    case MainActionType.SET_GAMES_TOTAL: {
+      return {
+        ...state,
+        gamesTotal: action.total,
+      };
+    }
+
+    case MainActionType.SET_SUGGESTIONS: {
+      return {
+        ...state,
+        suggestions: action.suggestions,
+        appPaths: action.appPaths,
+      };
+    }
+
+    case MainActionType.SET_LOCALE: {
+      return {
+        ...state,
+        localeCode: action.localeCode,
+      };
+    }
+
+    case MainActionType.SET_LANGUAGE: {
+      return {
+        ...state,
+        lang: action.lang,
+      };
+    }
+
+    case MainActionType.SET_LANGUAGE_LIST: {
+      return {
+        ...state,
+        langList: action.langList,
+      };
+    }
+
+    case MainActionType.SET_THEME_LIST: {
+      return {
+        ...state,
+        themeList: action.themeList,
+      };
+    }
+
+    case MainActionType.SET_PLAYLISTS: {
+      return {
+        ...state,
+        playlists: action.playlists,
+      };
+    }
+
+    case MainActionType.SET_UPGRADES: {
+      return {
+        ...state,
+        upgrades: action.upgrades,
+        upgradesDoneLoading: true,
+      };
+    }
+
+    case MainActionType.SET_UPDATE_INFO: {
+      return {
+        ...state,
+        updateInfo: action.updateInfo,
+      };
+    }
+
+    case MainActionType.CLICK_NEW_GAME: {
+      return {
+        ...state,
+        wasNewGameClicked: true,
+      };
+    }
+
+    case MainActionType.CLICK_NEW_GAME_END: {
+      return {
+        ...state,
+        wasNewGameClicked: false,
+      };
+    }
   }
 }
 
@@ -221,7 +335,7 @@ function createInitialState(): MainState {
     gamesTotal: -1,
     randomGames: [],
     requestingRandomGames: false,
-    localeCode: 'n',
+    localeCode: 'en-us',
     upgrades: [],
     gamesDoneLoading: false,
     upgradesDoneLoading: false,

--- a/src/renderer/store/main/reducer.ts
+++ b/src/renderer/store/main/reducer.ts
@@ -312,6 +312,51 @@ export function mainStateReducer(state: MainState = createInitialState(), action
         wasNewGameClicked: false,
       };
     }
+
+    case MainActionType.SHIFT_RANDOM_GAMES: {
+      if (state.randomGames.length >= 10) {
+        return {
+          ...state,
+          randomGames: state.randomGames.slice(5),
+        };
+      } else {
+        return {
+          ...state,
+          shiftRandomGames: true,
+        };
+      }
+    }
+
+    case MainActionType.REQUEST_RANDOM_GAMES: {
+      return {
+        ...state,
+        requestingRandomGames: true,
+      };
+    }
+
+    case MainActionType.RESPONSE_RANDOM_GAMES: {
+      return {
+        ...state,
+        randomGames: [
+          ...(
+            state.shiftRandomGames
+              ? state.randomGames.slice(5)
+              : state.randomGames
+          ),
+          ...action.games,
+        ],
+        requestingRandomGames: false,
+        shiftRandomGames: false,
+        gamesDoneLoading: true,
+      };
+    }
+
+    case MainActionType.CLEAR_RANDOM_GAMES: {
+      return {
+        ...state,
+        randomGames: state.randomGames.slice(0, 5),
+      };
+    }
   }
 }
 
@@ -335,6 +380,7 @@ function createInitialState(): MainState {
     gamesTotal: -1,
     randomGames: [],
     requestingRandomGames: false,
+    shiftRandomGames: false,
     localeCode: 'en-us',
     upgrades: [],
     gamesDoneLoading: false,

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -130,4 +130,46 @@ export type MainAction = {
 } | {
   type: MainActionType.SET_CREDITS;
   creditsData?: CreditsData;
+} | {
+  type: MainActionType.STOP_RENDER;
+} | {
+  type: MainActionType.OPEN_META_EXPORTER;
+  gameId: string;
+} | {
+  type: MainActionType.CLOSE_META_EXPORTER;
+} | {
+  type: MainActionType.ADD_LOADED;
+  loaded: BackInit[];
+} | {
+  type: MainActionType.SET_GAMES_TOTAL;
+  total: number;
+} | {
+  type: MainActionType.SET_SUGGESTIONS;
+  suggestions: Partial<GamePropSuggestions>;
+  appPaths: Record<string, string>;
+} | {
+  type: MainActionType.SET_LOCALE;
+  localeCode: string;
+} | {
+  type: MainActionType.SET_LANGUAGE;
+  lang: LangContainer;
+} | {
+  type: MainActionType.SET_LANGUAGE_LIST;
+  langList: LangFile[];
+} | {
+  type: MainActionType.SET_THEME_LIST;
+  themeList: Theme[];
+} | {
+  type: MainActionType.SET_PLAYLISTS;
+  playlists: Playlist[];
+} | {
+  type: MainActionType.SET_UPGRADES;
+  upgrades: UpgradeStage[];
+} | {
+  type: MainActionType.SET_UPDATE_INFO;
+  updateInfo: UpdateInfo;
+} | {
+  type: MainActionType.CLICK_NEW_GAME;
+} | {
+  type: MainActionType.CLICK_NEW_GAME_END;
 }

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -114,9 +114,8 @@ export type MainAction = {
   start: number;
   count: number;
 } | {
-  type: MainActionType.SET_VIEW_STATE;
+  type: MainActionType.REQUEST_VIEW_META;
   library: string;
-  state: Partial<View>;
 } | {
   type: MainActionType.SET_VIEW_META;
   library: string;
@@ -130,6 +129,10 @@ export type MainAction = {
   type: MainActionType.REQUEST_VIEW_PAGES;
   library: string;
   pages: number[];
+} | {
+  type: MainActionType.SET_VIEW_SELECTED_GAME;
+  library: string;
+  gameId?: string;
 } | {
   type: MainActionType.SET_CREDITS;
   creditsData?: CreditsData;

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -3,7 +3,6 @@ import { CreditsData } from '@renderer/credits/types';
 import { ViewGameSet } from '@renderer/interfaces';
 import { UpgradeStage } from '@renderer/upgrade/types';
 import { BackInit, PageKeyset, ResponseGameRange, SearchGamesOpts, ViewGame } from '@shared/back/types';
-import { BrowsePageLayout } from '@shared/BrowsePageLayout';
 import { GamePropSuggestions } from '@shared/interfaces';
 import { LangContainer, LangFile } from '@shared/lang';
 import { GameOrderBy, GameOrderReverse } from '@shared/order/interfaces';
@@ -33,8 +32,6 @@ export type View = {
   isDirty: boolean;
   /** Total number of results in the query of the most recent game page response (used for games even if dirty). */
   total?: number;
-  /** ID of the selected playlist. */
-  selectedPlaylistId?: string;
   /** ID of the selected game. */
   selectedGameId?: string;
   /** Most recent "start" page index that has been viewed. */
@@ -82,10 +79,6 @@ export type MainState = {
   /** Credits data (if any). */
   creditsData?: CreditsData;
   creditsDoneLoading: boolean;
-  /** Scale of the games. */
-  gameScale: number;
-  /** Layout of the browse page */
-  gameLayout: BrowsePageLayout;
   /** If the "New Game" button was clicked (silly way of passing the event from the footer the the browse page). */
   wasNewGameClicked: boolean;
   /** Current language container. */
@@ -110,6 +103,8 @@ export type MainAction = {
   showExtreme: boolean;
   orderBy: GameOrderBy;
   orderReverse: GameOrderReverse;
+  /** The playlistId can be of type string or undefined. Null means it will remain the same as before. */
+  playlistId: string | undefined | null;
 } | {
   type: MainActionType.SET_VIEW_BOUNDRIES;
   library: string;
@@ -132,4 +127,7 @@ export type MainAction = {
   type: MainActionType.REQUEST_VIEW_PAGES;
   library: string;
   pages: number[];
+} | {
+  type: MainActionType.SET_CREDITS;
+  creditsData?: CreditsData;
 }

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -1,0 +1,135 @@
+import { Playlist } from '@database/entity/Playlist';
+import { CreditsData } from '@renderer/credits/types';
+import { ViewGameSet } from '@renderer/interfaces';
+import { UpgradeStage } from '@renderer/upgrade/types';
+import { BackInit, PageKeyset, ResponseGameRange, SearchGamesOpts, ViewGame } from '@shared/back/types';
+import { BrowsePageLayout } from '@shared/BrowsePageLayout';
+import { GamePropSuggestions } from '@shared/interfaces';
+import { LangContainer, LangFile } from '@shared/lang';
+import { GameOrderBy, GameOrderReverse } from '@shared/order/interfaces';
+import { Theme } from '@shared/ThemeFile';
+import { UpdateInfo } from 'electron-updater';
+import { MainActionType, RequestState } from './enums';
+
+export type View = {
+  /** The most recent query used for this view. */
+  query: ViewQuery;
+  /** State of each page in the view. */
+  pageState: ViewPageStates;
+  /** Most recent meta. */
+  meta?: {
+    /** Total number of results in the query. */
+    total: number;
+    /** Page keyset of the results. */
+    pageKeyset: PageKeyset;
+  };
+  /** State of the meta request (undfined means the view is "idle" and no request should be made). */
+  metaState?: RequestState;
+  /** Games to display. */
+  games: ViewGameSet;
+  /** Unique identifier for the current "search" (used for validating that responses are not outdated). */
+  queryId: number;
+  /** If a new meta has been applied but the games of the old query are still present (this means the games should be discarded the next time a game page is received). */
+  isDirty: boolean;
+  /** Total number of results in the query of the most recent game page response (used for games even if dirty). */
+  total?: number;
+  /** ID of the selected playlist. */
+  selectedPlaylistId?: string;
+  /** ID of the selected game. */
+  selectedGameId?: string;
+  /** Most recent "start" page index that has been viewed. */
+  lastStart: number;
+  /** Most recent "count" of pages that has been viewed. */
+  lastCount: number;
+}
+
+export type ViewQuery = SearchGamesOpts & {
+  /** Query string. */
+  text: string;
+  /** If extreme games are included. */
+  extreme: boolean;
+}
+
+export type ViewPageStates = Partial<Record<number, RequestState>>
+
+export type MainState = {
+  views: Record<string, View | undefined>; // views[id] = view
+  libraries: string[];
+  serverNames: string[];
+  mad4fpEnabled: boolean;
+  playlists: Playlist[];
+  playlistIconCache: Record<string, string>; // [PLAYLIST_ID] = ICON_BLOB_URL
+  suggestions: Partial<GamePropSuggestions>;
+  appPaths: Record<string, string>;
+  platforms: Record<string, string[]>;
+  loaded: { [key in BackInit]: boolean; };
+  themeList: Theme[];
+  gamesTotal: number;
+  localeCode: string;
+
+  /** Random games for the Home page box */
+  randomGames: ViewGame[];
+  /** Whether we're currently requesting random games */
+  requestingRandomGames: boolean;
+  /** Data and state used for the upgrade system (optional install-able downloads from the HomePage). */
+  upgrades: UpgradeStage[];
+  /** If the Random games have loaded - Masked as 'Games' */
+  gamesDoneLoading: boolean;
+  /** If upgrades files have loaded */
+  upgradesDoneLoading: boolean;
+  /** Stop rendering to force component unmounts */
+  stopRender: boolean;
+  /** Credits data (if any). */
+  creditsData?: CreditsData;
+  creditsDoneLoading: boolean;
+  /** Scale of the games. */
+  gameScale: number;
+  /** Layout of the browse page */
+  gameLayout: BrowsePageLayout;
+  /** If the "New Game" button was clicked (silly way of passing the event from the footer the the browse page). */
+  wasNewGameClicked: boolean;
+  /** Current language container. */
+  lang: LangContainer;
+  /** Current list of available language files. */
+  langList: LangFile[];
+  /** Info of the update, if one was found */
+  updateInfo: UpdateInfo | undefined;
+  /** If the "Meta Edit Popup" is open. */
+  metaEditExporterOpen: boolean;
+  /** ID of the game used in the "Meta Edit Popup". */
+  metaEditExporterGameId: string;
+}
+
+export type MainAction = {
+  type: MainActionType.SET_STATE;
+  payload: Partial<MainState>;
+} | {
+  type: MainActionType.SET_VIEW_QUERY;
+  library: string;
+  searchText: string;
+  showExtreme: boolean;
+  orderBy: GameOrderBy;
+  orderReverse: GameOrderReverse;
+} | {
+  type: MainActionType.SET_VIEW_BOUNDRIES;
+  library: string;
+  start: number;
+  count: number;
+} | {
+  type: MainActionType.SET_VIEW_STATE;
+  library: string;
+  state: Partial<View>;
+} | {
+  type: MainActionType.SET_VIEW_META;
+  library: string;
+  keyset: PageKeyset;
+  total: number;
+} | {
+  type: MainActionType.ADD_VIEW_PAGES;
+  library: string;
+  ranges: ResponseGameRange<boolean>[];
+} | {
+  type: MainActionType.REQUEST_VIEW_PAGES;
+  library: string;
+  pages: number[];
+}

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -68,6 +68,9 @@ export type MainState = {
   randomGames: ViewGame[];
   /** Whether we're currently requesting random games */
   requestingRandomGames: boolean;
+  /** If the random games should be shiften when the request is complete. */
+  shiftRandomGames: boolean;
+
   /** Data and state used for the upgrade system (optional install-able downloads from the HomePage). */
   upgrades: UpgradeStage[];
   /** If the Random games have loaded - Masked as 'Games' */
@@ -172,4 +175,13 @@ export type MainAction = {
   type: MainActionType.CLICK_NEW_GAME;
 } | {
   type: MainActionType.CLICK_NEW_GAME_END;
+} | {
+  type: MainActionType.SHIFT_RANDOM_GAMES;
+} | {
+  type: MainActionType.REQUEST_RANDOM_GAMES;
+} | {
+  type: MainActionType.RESPONSE_RANDOM_GAMES;
+  games: ViewGame[];
+} | {
+  type: MainActionType.CLEAR_RANDOM_GAMES;
 }

--- a/src/renderer/store/main/types.ts
+++ b/src/renderer/store/main/types.ts
@@ -116,18 +116,22 @@ export type MainAction = {
 } | {
   type: MainActionType.REQUEST_VIEW_META;
   library: string;
+  queryId: number;
 } | {
   type: MainActionType.SET_VIEW_META;
   library: string;
+  queryId: number;
   keyset: PageKeyset;
   total: number;
 } | {
   type: MainActionType.ADD_VIEW_PAGES;
   library: string;
+  queryId: number;
   ranges: ResponseGameRange<boolean>[];
 } | {
   type: MainActionType.REQUEST_VIEW_PAGES;
   library: string;
+  queryId: number;
   pages: number[];
 } | {
   type: MainActionType.SET_VIEW_SELECTED_GAME;


### PR DESCRIPTION
The state of the App component is now kept in a Redux store instead (the store is called "main").

Views now keep a unique ID for the most recent query. This allows it to ignore outdated actions and eliminate some race conditions.

Adding games to the random games queue no longer discards a portion of the queued games.

Some minor cleanup has been made (remove some redundant state, remove some props passed down from main etc.)