### PR TITLE
feat: Add keep archive key option to curate page

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -298,6 +298,7 @@
     "deleteAll": "Delete All",
     "deleteAllDesc": "Delete all curations that are currently loaded",
     "saveImportedCurations": "Save Imported Curations",
+    "keepArchiveKey": "Keep Curation Archive UUID",
     "symlinkCurationContent": "Symlink Curation Content Folder (Admin prompts on Windows, Required for MAD4FP)",
     "openCurationsFolder": "Curations Folder",
     "openCurationsFolderDesc": "Open the Curations folder in explorer",

--- a/src/renderer/components/pages/CuratePage.tsx
+++ b/src/renderer/components/pages/CuratePage.tsx
@@ -322,10 +322,8 @@ export function CuratePage(props: CuratePageProps) {
       // Don't use percentDone
       ProgressDispatch.setUsePercentDone(statusProgress, false);
       for (const archivePath of filePaths) {
-        // Mark as indexed so can index ourselves after extraction
-        const key = uuid();
         // Extract files to curation folder
-        await importCurationArchive(archivePath, key, newProgress(progressKey, progressDispatch))
+        await importCurationArchive(archivePath, props.preferencesData.keepArchiveKey, newProgress(progressKey, progressDispatch))
         .then(async key => {
           const curationPath = path.join(window.Shared.config.fullFlashpointPath, 'Curations', 'Working', key);
           await loadCurationFolder(key, curationPath, defaultGameMetaValues, dispatch, props);
@@ -338,7 +336,7 @@ export function CuratePage(props: CuratePageProps) {
       }
     }
     ProgressDispatch.finished(statusProgress);
-  }, [dispatch, indexedCurations, setIndexedCurations]);
+  }, [dispatch, indexedCurations, setIndexedCurations, props.preferencesData.keepArchiveKey]);
 
   // Load Curation Folder Callback
   const onLoadCurationFolderClick = useCallback(async () => {
@@ -418,6 +416,13 @@ export function CuratePage(props: CuratePageProps) {
   const onSaveImportsToggle = useCallback((isChecked: boolean) => {
     updatePreferencesData({
       saveImportedCurations: isChecked
+    });
+  }, []);
+
+  // On keep archive key toggle
+  const onKeepArchiveKeyToggle = useCallback((isChecked: boolean) => {
+    updatePreferencesData({
+      keepArchiveKey: isChecked
     });
   }, []);
 
@@ -589,6 +594,13 @@ export function CuratePage(props: CuratePageProps) {
             </div>
             <div className='curate-page__floating-box__divider'/>
             <div className='curate-page__checkbox'>
+              <div className='curate-page__checkbox-text'>{strings.curate.keepArchiveKey}</div>
+              <CheckBox
+                onToggle={onKeepArchiveKeyToggle}
+                checked={props.preferencesData.keepArchiveKey} />
+            </div>
+            <div className='curate-page__floating-box__divider'/>
+            <div className='curate-page__checkbox'>
               <div className='curate-page__checkbox-text'>{strings.curate.symlinkCurationContent}</div>
               <CheckBox
                 onToggle={onSymlinkCurationContentToggle}
@@ -601,7 +613,7 @@ export function CuratePage(props: CuratePageProps) {
   ), [curateBoxes, progressComponent, strings, state.curations.length,
     onImportAllClick, onLoadCurationArchiveClick, onLoadCurationFolderClick, onLoadMetaClick,
     props.preferencesData.curatePageLeftSidebarWidth, props.preferencesData.browsePageShowLeftSidebar,
-    props.preferencesData.saveImportedCurations, props.preferencesData.symlinkCurationContent]);
+    props.preferencesData.saveImportedCurations, props.preferencesData.keepArchiveKey, props.preferencesData.symlinkCurationContent]);
 }
 
 function renderImportAllButton({ activate, activationCounter, reset, extra }: ConfirmElementArgs<[LangContainer['curate'], boolean]>): JSX.Element {

--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -324,6 +324,7 @@ const langTemplate = {
     'loadFolder',
     'loadFolderDesc',
     'saveImportedCurations',
+    'keepArchiveKey',
     'symlinkCurationContent',
     'noCurations',
     'id',

--- a/src/shared/preferences/interfaces.ts
+++ b/src/shared/preferences/interfaces.ts
@@ -48,6 +48,8 @@ export type IAppPreferencesData = {
   defaultLibrary: string;
   /** Save curations after importing */
   saveImportedCurations: boolean;
+  /** Assign the same UUID to imported games as in the curation archive */
+  keepArchiveKey: boolean;
   /** Whether to symlink or copy curation content when running (Symlink required for MAD4FP) */
   symlinkCurationContent: boolean;
   /** Download missing thumbnails/screenshots from a remote server. */

--- a/src/shared/preferences/util.ts
+++ b/src/shared/preferences/util.ts
@@ -53,6 +53,7 @@ export const defaultPreferencesData: Readonly<IAppPreferencesData> = Object.free
     maximized: false,
   }),
   saveImportedCurations: true,
+  keepArchiveKey: true,
   symlinkCurationContent: true,
   onDemandImages: false,
   showLogSource: Object.freeze({
@@ -104,6 +105,7 @@ export function overwritePreferenceData(
   parser.prop('gamesOrder',                  v => source.gamesOrder                  = strOpt(v, gameOrderReverseOptions, 'ASC'));
   parser.prop('defaultLibrary',              v => source.defaultLibrary              = str(v));
   parser.prop('saveImportedCurations',       v => source.saveImportedCurations       = !!v);
+  parser.prop('keepArchiveKey',              v => source.keepArchiveKey              = !!v);
   parser.prop('symlinkCurationContent',      v => source.symlinkCurationContent      = !!v);
   parser.prop('onDemandImages',              v => source.onDemandImages              = !!v);
   parser.prop('excludedRandomLibraries',     v => source.excludedRandomLibraries     = strArray(v), true);


### PR DESCRIPTION
Currently, the launcher will assign a new UUID to every imported curation archive, this is potentially unwanted behavior, as it doesn't allow of proper tracking of games outside of the launcher. This change adds a checkbox to the curation page that allows reuse of UUIDs from said archives whenever possible, this would be enabled by default.