### PR TITLE
fix: Escape odd numbers of single quotes in launch commands on Linux

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -395,10 +395,10 @@ function escapeWin(str: string): string {
  */
 function escapeLinuxArgs(str: string): string {
   // Characters to always escape:
-  let escapeChars: string[] = ["~","`","#","$","&","*","(",")","\\","|","[","\\]","{","}",";","<",">","?","!"];
+  const escapeChars: string[] = ['~','`','#','$','&','*','(',')','\\\\','|','[','\\]','{','}',';','<','>','?','!'];
   if(str.match(/\'/gi) == null || (str.match(/\'/gi)!.join("").length) % 2 == 0) {
-    escapeChars.unshift("[");
-    escapeChars.push("]");
+    escapeChars.unshift('[');
+    escapeChars.push(']');
     return (
       splitQuotes(str)
       .reduce((acc, val, i) => acc + ((i % 2 === 0)
@@ -407,9 +407,9 @@ function escapeLinuxArgs(str: string): string {
       ), '')
     );
   } else { // If there's an odd number of single quotes, escape those too.
-    escapeChars.unshift("[");
-    escapeChars.push("'");
-    escapeChars.push("]");
+    escapeChars.unshift('[');
+    escapeChars.push('\'');
+    escapeChars.push(']');
     return (
       splitQuotes(str)
       .reduce((acc, val, i) => acc + ((i % 2 === 0)

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -396,28 +396,22 @@ function escapeWin(str: string): string {
 function escapeLinuxArgs(str: string): string {
   // Characters to always escape:
   const escapeChars: string[] = ['~','`','#','$','&','*','(',')','\\\\','|','[','\\]','{','}',';','<','>','?','!'];
-  if (str.match(/\'/gi) == null || (str.match(/\'/gi)!.join('').length) % 2 == 0) {
+  const match = str.match(/'/gi);
+  if (match == null || match.join('').length % 2 == 0) {
     escapeChars.unshift('[');
     escapeChars.push(']');
-    return (
-      splitQuotes(str)
-      .reduce((acc, val, i) => acc + ((i % 2 === 0)
-        ? val.replace(new RegExp(escapeChars.join(''), 'g'), '\\$&')
-        : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
-      ), '')
-    );
   } else { // If there's an odd number of single quotes, escape those too.
     escapeChars.unshift('[');
     escapeChars.push('\'');
     escapeChars.push(']');
-    return (
-      splitQuotes(str)
-      .reduce((acc, val, i) => acc + ((i % 2 === 0)
-        ? val.replace(new RegExp(escapeChars.join(''), 'g'), '\\$&')
-        : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
-      ), '')
-    );
   }
+  return (
+    splitQuotes(str)
+    .reduce((acc, val, i) => acc + ((i % 2 === 0)
+      ? val.replace(new RegExp(escapeChars.join(''), 'g'), '\\$&')
+      : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
+    ), '')
+  );
 }
 
 /**

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -396,13 +396,13 @@ function escapeWin(str: string): string {
 function escapeLinuxArgs(str: string): string {
   // Characters to always escape:
   const escapeChars: string[] = ['~','`','#','$','&','*','(',')','\\\\','|','[','\\]','{','}',';','<','>','?','!'];
-  if(str.match(/\'/gi) == null || (str.match(/\'/gi)!.join("").length) % 2 == 0) {
+  if (str.match(/\'/gi) == null || (str.match(/\'/gi)!.join('').length) % 2 == 0) {
     escapeChars.unshift('[');
     escapeChars.push(']');
     return (
       splitQuotes(str)
       .reduce((acc, val, i) => acc + ((i % 2 === 0)
-        ? val.replace(new RegExp(escapeChars.join(""), 'g'), '\\$&')
+        ? val.replace(new RegExp(escapeChars.join(''), 'g'), '\\$&')
         : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
       ), '')
     );
@@ -413,7 +413,7 @@ function escapeLinuxArgs(str: string): string {
     return (
       splitQuotes(str)
       .reduce((acc, val, i) => acc + ((i % 2 === 0)
-        ? val.replace(new RegExp(escapeChars.join(""), 'g'), '\\$&')
+        ? val.replace(new RegExp(escapeChars.join(''), 'g'), '\\$&')
         : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
       ), '')
     );

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -394,13 +394,30 @@ function escapeWin(str: string): string {
  * ( According to this: https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash )
  */
 function escapeLinuxArgs(str: string): string {
-  return (
-    splitQuotes(str)
-    .reduce((acc, val, i) => acc + ((i % 2 === 0)
-      ? val.replace(/[~`#$&*()\\|[\]{};<>?!]/g, '\\$&')
-      : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
-    ), '')
-  );
+  // Characters to always escape:
+  let escapeChars: string[] = ["~","`","#","$","&","*","(",")","\\","|","[","\\]","{","}",";","<",">","?","!"];
+  if(str.match(/\'/gi) == null || (str.match(/\'/gi)!.join("").length) % 2 == 0) {
+    escapeChars.unshift("[");
+    escapeChars.push("]");
+    return (
+      splitQuotes(str)
+      .reduce((acc, val, i) => acc + ((i % 2 === 0)
+        ? val.replace(new RegExp(escapeChars.join(""), 'g'), '\\$&')
+        : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
+      ), '')
+    );
+  } else { // If there's an odd number of single quotes, escape those too.
+    escapeChars.unshift("[");
+    escapeChars.push("'");
+    escapeChars.push("]");
+    return (
+      splitQuotes(str)
+      .reduce((acc, val, i) => acc + ((i % 2 === 0)
+        ? val.replace(new RegExp(escapeChars.join(""), 'g'), '\\$&')
+        : '"' + val.replace(/[$!\\]/g, '\\$&') + '"'
+      ), '')
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #159.

As explained in #159, launching certain games currently fails on Linux because single quotes (apostrophes) are not escaped; however, some games also use single quote pairs that should not be escaped. Searching through the current catalog, there are 542 titles with one or more `'` in their launch command:

- 248 titles currently have a single `'` in their launch command (244 Flash and 4 HTML5).
- 294 currently have two or more `'` in their launch command (250 Shockwave and 44 Flash).
  - All of these have an even number of `'` (there are no three, five, seven, etc. occurrences.)

Roughly speaking, the Shockwave titles use single quotes that should not be escaped, while Flash and HTML5 titles use apostrophes in URLs that should be escaped. This PR would not fix the 44 Flash titles that use even numbers of apostrophes, but it would fix the 248 that only have a single apostrophe, without affecting the 250 that are using single quote pairs correctly.

(I wrote the PR before I saw that there are no higher odd numbers in play, but it wouldn't change much to only escape if there's a single apostrophe. It stands to reason that if there's an odd number, it means something wouldn't be closed, so either they all need to be escaped, or the command needs to be revised.)