### PR TITLE
Include parentGame in addApp searches. Required for AutoMount extension.

### DIFF
--- a/src/back/game/GameManager.ts
+++ b/src/back/game/GameManager.ts
@@ -198,9 +198,9 @@ export namespace GameManager {
   /** Find an add apps with the specified ID. */
   export async function findAddApp(id?: string, filter?: FindOneOptions<AdditionalApp>): Promise<AdditionalApp | undefined> {
     if (id || filter) {
-      if(!filter) {
+      if (!filter) {
         filter = {
-          relations: ["parentGame"]
+          relations: ['parentGame']
         };
       }
       const addAppRepository = getManager().getRepository(AdditionalApp);

--- a/src/back/game/GameManager.ts
+++ b/src/back/game/GameManager.ts
@@ -198,6 +198,11 @@ export namespace GameManager {
   /** Find an add apps with the specified ID. */
   export async function findAddApp(id?: string, filter?: FindOneOptions<AdditionalApp>): Promise<AdditionalApp | undefined> {
     if (id || filter) {
+      if(!filter) {
+        filter = {
+          relations: ["parentGame"]
+        };
+      }
       const addAppRepository = getManager().getRepository(AdditionalApp);
       return addAppRepository.findOne(id, filter);
     }


### PR DESCRIPTION
I'm not sure if this is the cleanest place to add the relation filter, or if it should go in the client (which doesn't itself give any filters, so I'm not sure why this accepts a filter).