### PR TITLE
feat: add ExecMapping support for non-native Linux platforms.

### DIFF
--- a/src/back/Execs.ts
+++ b/src/back/Execs.ts
@@ -42,10 +42,12 @@ function parseExecMapping(parser: IObjectParserProp<any>) : ExecMapping {
   const parsed: ExecMapping = {
     win32: '',
     linux: undefined,
+    wine: undefined,
     darwin: undefined,
   };
   parser.prop('win32',  v => parsed.win32  = parseVarStr(str(v)));
   parser.prop('linux',  v => parsed.linux  = parseVarStr(str(v)), true);
+  parser.prop('wine',   v => parsed.wine   = parseVarStr(str(v)), true);
   parser.prop('darwin', v => parsed.darwin = parseVarStr(str(v)), true);
   return parsed;
 }

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -294,16 +294,27 @@ export namespace GameLauncher {
       return filePath.substr(0, filePath.length - 4) + '.sh';
     }
 
-    // Skip mapping if on Windows or Native application was not requested
-    if (platform !== 'win32' && native) {
+    // Skip mapping if on Windows
+    if (platform !== 'win32') {
       for (let i = 0; i < execMappings.length; i++) {
         const mapping = execMappings[i];
         if (mapping.win32 === filePath) {
           switch (platform) {
             case 'linux':
-              return mapping.linux || mapping.win32;
+              // If we are trying to run this game natively:
+              if (native) {
+                // Use the native binary (if configured.)
+                return mapping.linux || mapping.win32;
+              } else {
+                // Otherwise, use the wine binary (if configured.)
+                return mapping.wine || mapping.win32;
+              }
             case 'darwin':
-              return mapping.darwin || mapping.win32;
+              // If we are trying to run this game natively:
+              if (native) {
+                // Use the native binary (if configured.)
+                return mapping.darwin || mapping.win32;
+              }
             default:
               return filePath;
           }

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -315,6 +315,7 @@ export namespace GameLauncher {
                 // Use the native binary (if configured.)
                 return mapping.darwin || mapping.win32;
               }
+              break;
             default:
               return filePath;
           }

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -218,6 +218,8 @@ export type ExecMapping = {
   win32: string;
   /** Linux path (if exists) */
   linux?: string;
+  /** Wine path (if exists) */
+  wine?: string;
   /** Mac path (if exists) */
   darwin?: string;
 }


### PR DESCRIPTION
Add support for applicationpath configuration with execs.json for
non-native Linux platforms. If an override path is not found in
execs.json under the key "wine", keep the old default behavior of
using the unconfigurable WINE launch command.
Previous behavior: if "native" was not checked, the system's WINE
would be used to launch the game. This is not sufficiently configurable,
and the long-term plan will use a portable docker environment, launched
from shell scripts.