### PR TITLE
fix: Continue trying ports on EACCES.

### DIFF
--- a/src/back/SocketServer.ts
+++ b/src/back/SocketServer.ts
@@ -309,7 +309,7 @@ function startServer(minPort: number, maxPort: number, host: string | undefined)
       }
     }
     function onError(error: Error): void {
-      if ((error as any).code === 'EADDRINUSE') {
+      if ((error as any).code === 'EADDRINUSE' || (error as any).code === 'EACCES') {
         tryListen();
       } else {
         reject(error);


### PR DESCRIPTION
Hyper-V reserves random port ranges, resulting in an EACCES when
we try to listen on a port in that range.