### PR TITLE
feat: Add disableExtremeGames toggle in Config tab (#236)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -68,6 +68,8 @@
     "saveAndRestart": "Save and Restart",
     "saveAndClose": "Save and Close",
     "tagFilterGroupEditor": "Tag Filter Group Editor"
+    "disableExtreme": "Disable Extreme Games"
+    "disableExtremeDesc": "Hides the option to edit Extreme tag filters, and itself."
   },
   "home": {
     "updateHeader": "Launcher Update",

--- a/src/renderer/components/pages/ConfigPage.tsx
+++ b/src/renderer/components/pages/ConfigPage.tsx
@@ -174,6 +174,13 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
               {/* Show Extreme Games */}
               {((!this.props.preferencesData.disableExtremeGames)) ? (
                 <ConfigBoxCheckbox
+                  title={strings.disableExtreme}
+                  description={strings.disableExtremeDesc}
+                  checked={this.props.preferencesData.disableExtremeGames}
+                  onToggle={this.onDisableExtremeChange} />
+              ) : undefined }
+              {((!this.props.preferencesData.disableExtremeGames)) ? (
+                <ConfigBoxCheckbox
                   title={strings.extremeGames}
                   description={strings.extremeGamesDesc}
                   checked={this.props.preferencesData.browsePageShowExtreme}
@@ -707,7 +714,12 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
       </div>
     );
   }
-
+  onDisableExtremeChange = (isChecked: boolean): void => {
+    updatePreferencesData({ disableExtremeGames: isChecked });
+    if (isChecked) {
+      updatePreferencesData({ browsePageShowExtreme: false });
+    }
+  }
   onShowExtremeChange = (isChecked: boolean): void => {
     updatePreferencesData({ browsePageShowExtreme: isChecked });
   }

--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -75,6 +75,8 @@ const langTemplate = {
     'saveAndClose',
     'browse',
     'tagFilterGroupEditor',
+    'disableExtreme',
+    'disableExtremeDesc',
   ] as const,
   home: [
     'updateHeader',


### PR DESCRIPTION
This PR addresses #236, adding a "Disable Extreme Games" toggle in the Config tab. When this is turned on, it will set `disableExtremeGames` to true, and `browsePageShowExtreme` to false.
The new toggle is only visible when `disableExtremeGames` is false, so turning it on will hide it.

As for the title/description: I put in something temporary for English, feel free to change it. Other languages will need translations.