### PR TITLE
fix: mac support

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -460,7 +460,8 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
     }
   });
   state.languageWatcher.on('error', console.error);
-  const langFolder = path.join(content.isDev ? process.cwd() : path.dirname(content.exePath), 'lang');
+  // On mac, exePath is Flashpoint.app/Contents/MacOS/flashpoint, and lang is at Flashpoint.app/Contents/lang.
+  const langFolder = path.join(content.isDev ? process.cwd() : process.platform == 'darwin' ? path.resolve(path.dirname(content.exePath), '..') : path.dirname(content.exePath), 'lang');
   fs.stat(langFolder, (error) => {
     if (!error) { state.languageWatcher.watch(langFolder); }
     else {

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -244,7 +244,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   state.logFile = new LogFile(
     state.isDev ?
       path.join(process.cwd(), 'launcher.log')
-      : path.join(path.dirname(content.exePath), 'launcher.log'));
+      : path.join(process.platform == 'darwin' ? state.configFolder : path.dirname(content.exePath), 'launcher.log'));
 
   const addLog = (entry: ILogEntry): number => { return state.log.push(entry) - 1; };
   global.log = {
@@ -262,6 +262,12 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
 
   // Read configs & preferences
   state.config = await ConfigFile.readOrCreateFile(path.join(state.configFolder, CONFIG_FILENAME));
+
+  // If we're on mac and the flashpoint path is relative, resolve it relative to the configFolder path.
+  state.config.flashpointPath = process.platform == 'darwin' && state.config.flashpointPath[0] != '/'
+    ? path.resolve(state.configFolder, state.config.flashpointPath)
+    : state.config.flashpointPath;
+
   // @TODO Figure out why async loading isn't always working?
   try {
     state.preferences = await PreferencesFile.readOrCreateFile(path.join(state.config.flashpointPath, PREFERENCES_FILENAME));

--- a/src/main/Util.ts
+++ b/src/main/Util.ts
@@ -38,5 +38,7 @@ export function getMainFolderPath(installed: boolean | undefined): string {
     ? path.join(app.getPath('appData'), 'flashpoint-launcher') // Installed
     : isDev
       ? process.cwd() // Dev
-      : path.dirname(app.getPath('exe')); // Portable
+      : process.platform == 'darwin'
+        ? path.resolve(path.dirname(app.getPath('exe')), '../../..')
+        : path.dirname(app.getPath('exe')); // Portable
 }


### PR DESCRIPTION
This PR fixes four issues that affected MacOS builds.

1. `state.mainFolderPath` (and hence `configFolder`, too) was being set to `DIR/Flashpoint.app/Contents/MacOS`, rather than `DIR`. (#296)
2. The launcher.log was being placed in `DIR/Flashpoint.app/Contents/MacOS`, rather than `DIR`.
3. `state.config.flashpointPath` was interpreted as relative to the current working directory, which is set to `/` by Finder. This was fixed by interpreting a relative `flashpointPath` as relative to the `configFolder`, not relative to the current working directory.
4. The path for the lang jsons was defaulting to `DIR/Flashpoint.app/Contents/MacOS/lang`, instead of `DIR/Flashpoint.app/Contents/lang`.

All of the fixes only take effect when on Mac, so they shouldn't break any other platforms.