### PR TITLE
Make macOS able to launch brew-installed (mostly wine'd but php/qemu too) executables.

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -332,9 +332,10 @@ export namespace GameLauncher {
     // When using Linux, use the proxy created in BackgroundServices.ts
     // This is only needed on Linux because the proxy is installed on system
     // level entire system when using Windows.
+    // When using WINE on mac, the proxy variable is needed as well.
     return {
       // Add proxy env vars if it's running on linux
-      ...((process.platform === 'linux' && proxy !== '') ? { http_proxy: `http://${proxy}/` } : null),
+      ...((process.platform === 'linux' || process.platform === 'darwin' && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` : null),
       // Copy this processes environment variables
       ...process.env,
     };

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -335,7 +335,7 @@ export namespace GameLauncher {
     // When using WINE on mac, the proxy variable is needed as well.
     return {
       // Add proxy env vars if it's running on linux
-      ...((process.platform === 'linux' || process.platform === 'darwin' && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` : null),
+      ...((process.platform === 'linux' || process.platform === 'darwin' && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` } : null),
       // Copy this processes environment variables
       ...process.env,
     };

--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -335,7 +335,7 @@ export namespace GameLauncher {
     // When using WINE on mac, the proxy variable is needed as well.
     return {
       // Add proxy env vars if it's running on linux
-      ...((process.platform === 'linux' || process.platform === 'darwin' && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` } : null),
+      ...(((process.platform === 'linux' || process.platform === 'darwin') && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` } : null),
       // Copy this processes environment variables
       ...process.env,
     };

--- a/src/back/ManagedChildProcess.ts
+++ b/src/back/ManagedChildProcess.ts
@@ -115,6 +115,11 @@ export class ManagedChildProcess extends EventEmitter {
         this.process = execFile(this.info.filename, this.info.arguments, { cwd: this.cwd, env: this.env });
       } else {
         if (process.platform == 'darwin') {
+          if (this.env === undefined) {
+            this.env = {PATH: ""};
+          } else if (this.env.PATH === undefined) {
+            this.env.PATH = "";
+          }
           // @ts-ignore This won't be undefined, despite what tsc says.
           let pathArr: string[] = this.env.PATH.split(':');
           // HACK: manually read in /etc/paths to PATH. Needs to be done on Mac, because otherwise

--- a/src/back/ManagedChildProcess.ts
+++ b/src/back/ManagedChildProcess.ts
@@ -131,7 +131,7 @@ export class ManagedChildProcess extends EventEmitter {
           }
           // @ts-ignore This won't be undefined, despite what tsc says.
           this.env.PATH = pathArr.join(':');
-          this.process = exec(this.info.filename + ' ' + this.info.arguments, { cwd: this.cwd, env: this.env});
+          this.process = exec(this.info.filename + ' "' + this.info.arguments.join('" "') + '"', { cwd: this.cwd, env: this.env});
         } else {
           this.process = spawn(this.info.filename, this.info.arguments, { cwd: this.cwd, detached: this.detached, shell: this.shell , env: this.env});
         }

--- a/src/back/ManagedChildProcess.ts
+++ b/src/back/ManagedChildProcess.ts
@@ -116,12 +116,12 @@ export class ManagedChildProcess extends EventEmitter {
       } else {
         if (process.platform == 'darwin') {
           if (this.env === undefined) {
-            this.env = {PATH: ""};
-          } else if (this.env.PATH === undefined) {
-            this.env.PATH = "";
+            this.env = {};
           }
-          // @ts-ignore This won't be undefined, despite what tsc says.
-          let pathArr: string[] = this.env.PATH.split(':');
+          if (this.env.PATH === undefined) {
+            this.env.PATH = '';
+          }
+          const pathArr: string[] = this.env.PATH.split(':');
           // HACK: manually read in /etc/paths to PATH. Needs to be done on Mac, because otherwise
           // the brew path won't be found.
           for (const entry of readFileSync('/etc/paths').toString().split('\n')) {
@@ -129,7 +129,6 @@ export class ManagedChildProcess extends EventEmitter {
               pathArr.push(entry);
             }
           }
-          // @ts-ignore This won't be undefined, despite what tsc says.
           this.env.PATH = pathArr.join(':');
           this.process = exec(this.info.filename + ' "' + this.info.arguments.join('" "') + '"', { cwd: this.cwd, env: this.env});
         } else {

--- a/src/back/ManagedChildProcess.ts
+++ b/src/back/ManagedChildProcess.ts
@@ -1,14 +1,14 @@
 import { IBackProcessInfo, INamedBackProcessInfo, ProcessState } from '@shared/interfaces';
 import { ILogPreEntry } from '@shared/Log/interface';
 import { Coerce } from '@shared/utils/Coerce';
-import { ChildProcess, execFile, spawn, exec } from 'child_process';
+import { ChildProcess, exec, execFile, spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import * as flashpoint from 'flashpoint-launcher';
+import { readFileSync } from 'fs';
 import * as readline from 'readline';
 import * as treeKill from 'tree-kill';
 import { ApiEmitter } from './extensions/ApiEmitter';
 import { Disposable } from './util/lifecycle';
-import { readFileSync } from 'fs';
 
 const { str } = Coerce;
 


### PR DESCRIPTION
Previously, `wine` wasn't on PATH, because macOS applications are launched with a very odd/minimal PATH.

This *kinda* fixes that - it reads /etc/paths into PATH before launching any games. It's a bit of a hack, but it works. Note that this change will only take effect when the launcher is running on macOS.

This also adds an extra proxy environment variable: the `http_proxy`/`HTTP_PROXY` capitalization convention is a bit unclear (i.e. will likely change depending on the program), so I wanted to cover all the bases.

The eslint check will fail on this. That is because I chose not to fix the missing semicolon in DeveloperPage.tsx, as doing so would cause conflicts with other PRs.