### PR TITLE
fix: use the right path for 7za on Mac.

### DIFF
--- a/src/back/util/SevenZip.ts
+++ b/src/back/util/SevenZip.ts
@@ -4,7 +4,7 @@ function get7zExec(isDev: boolean, exePath: string): string {
   const basePath = isDev ? process.cwd() : path.dirname(exePath);
   switch (process.platform) {
     case 'darwin':
-      return path.join(basePath, 'extern/7zip-bin/mac', '7za');
+      return path.join(basePath, '../extern/7zip-bin/mac', '7za');
     case 'win32':
       return path.join(basePath, 'extern/7zip-bin/win', process.arch, '7za');
     case 'linux':


### PR DESCRIPTION
`path.join` will resolve the `..` properly, resulting in the correct path.