### PR TITLE
Fix/0kb prefs hang

### DIFF
--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -267,7 +267,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   } catch (e) {
     console.log(e);
     // Fatal, quit.
-    send({quit: true, errorMessage: "Invalid config.json!"});
+    send({quit: true, errorMessage: 'Invalid config.json!'});
     return;
   }
 
@@ -282,7 +282,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   } catch (e) {
     console.log(e);
     // Fatal, quit.
-    send({quit: true, errorMessage: "Invalid preferences.json! Is it 0 KB?"});
+    send({quit: true, errorMessage: 'Invalid preferences.json! Is it 0 KB?'});
     return;
   }
   try {

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -273,7 +273,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
     state.preferences = await PreferencesFile.readOrCreateFile(path.join(state.config.flashpointPath, PREFERENCES_FILENAME));
   } catch (e) {
     console.log(e);
-    exit(state);
+    send({quit: true});
     return;
   }
   const [extConf] = await (Promise.all([
@@ -632,7 +632,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   }
 
   // Respond
-  send(state.socketServer.port, () => {
+  send({port: state.socketServer.port}, () => {
     state.apiEmitters.onDidInit.fire();
   });
 

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -261,7 +261,15 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
   log.info('Launcher', `Starting Flashpoint Launcher ${versionStr}`);
 
   // Read configs & preferences
-  state.config = await ConfigFile.readOrCreateFile(path.join(state.configFolder, CONFIG_FILENAME));
+  // readOrCreateFile can throw errors, let's wrap it in try-catch each time.
+  try {
+    state.config = await ConfigFile.readOrCreateFile(path.join(state.configFolder, CONFIG_FILENAME));
+  } catch (e) {
+    console.log(e);
+    // Fatal, quit.
+    send({quit: true, errorMessage: "Invalid config.json!"});
+    return;
+  }
 
   // If we're on mac and the flashpoint path is relative, resolve it relative to the configFolder path.
   state.config.flashpointPath = process.platform == 'darwin' && state.config.flashpointPath[0] != '/'
@@ -273,13 +281,19 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
     state.preferences = await PreferencesFile.readOrCreateFile(path.join(state.config.flashpointPath, PREFERENCES_FILENAME));
   } catch (e) {
     console.log(e);
-    send({quit: true});
+    // Fatal, quit.
+    send({quit: true, errorMessage: "Invalid preferences.json! Is it 0 KB?"});
     return;
   }
-  const [extConf] = await (Promise.all([
-    ExtConfigFile.readOrCreateFile(path.join(state.config.flashpointPath, EXT_CONFIG_FILENAME))
-  ]));
-  state.extConfig = extConf;
+  try {
+    const [extConf] = await (Promise.all([
+      ExtConfigFile.readOrCreateFile(path.join(state.config.flashpointPath, EXT_CONFIG_FILENAME))
+    ]));
+    state.extConfig = extConf;
+  } catch (e) {
+    console.log(e);
+    // Non-fatal, don't quit.
+  }
 
   // Create Game Data Directory and clean up temp files
   const fullDataPacksFolderPath = path.join(state.config.flashpointPath, state.preferences.dataPacksFolderPath);
@@ -295,6 +309,7 @@ async function onProcessMessage(message: any, sendHandle: any): Promise<void> {
     });
   } catch (error) {
     console.log('Failed to create default Data Packs folder!');
+    // Non-fatal, don't quit.
   }
 
 

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -139,10 +139,12 @@ export function main(init: Init): void {
       p = p.then(() => new Promise((resolve, reject) => {
         state.backProc = fork(path.join(__dirname, '../back/index.js'), undefined, { detached: true });
         // Wait for process to initialize
-        state.backProc.once('message', (port) => {
-          if (port >= 0) {
-            state.backHost.port = port as string;
+        state.backProc.once('message', (message: any) => {
+          if (message.port) {
+            state.backHost.port = message.port as string;
             resolve();
+          } else if (message.quit){
+            app.quit();
           } else {
             reject(new Error('Failed to start server in back process. Perhaps because it could not find an available port.'));
           }

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -145,7 +145,7 @@ export function main(init: Init): void {
             resolve();
           } else if (message.quit) {
             if (message.errorMessage) {
-              dialog.showErrorBox("Flashpoint Startup Error", message.errorMessage);
+              dialog.showErrorBox('Flashpoint Startup Error', message.errorMessage);
             }
             app.quit();
           } else {

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -143,7 +143,10 @@ export function main(init: Init): void {
           if (message.port) {
             state.backHost.port = message.port as string;
             resolve();
-          } else if (message.quit){
+          } else if (message.quit) {
+            if (message.errorMessage) {
+              dialog.showErrorBox("Flashpoint Startup Error", message.errorMessage);
+            }
             app.quit();
           } else {
             reject(new Error('Failed to start server in back process. Perhaps because it could not find an available port.'));


### PR DESCRIPTION
Fixes #238.

Previously: the backend process would exit properly, but the frontend process would hang, waiting for an init signal from the backend process.

Now: the backend process sends a `quit` message and an error string to the frontend process if there is an error parsing `preferences.json` or `config.json`. When the frontend recieves the `quit` message, it displays an error box and then quits.