### PR TITLE
Fix logoset caching.

### DIFF
--- a/src/renderer/components/pages/ConfigPage.tsx
+++ b/src/renderer/components/pages/ConfigPage.tsx
@@ -6,7 +6,7 @@ import { AppExtConfigData } from '@shared/config/interfaces';
 import { ExtConfigurationProp, ExtensionContribution, IExtensionDescription, ILogoSet } from '@shared/extensions/interfaces';
 import { autoCode, LangContainer, LangFile } from '@shared/lang';
 import { memoizeOne } from '@shared/memoize';
-import { updatePreferencesData } from '@shared/preferences/util';
+import { updatePreferencesData, updatePreferencesDataAsync } from '@shared/preferences/util';
 import { ITheme } from '@shared/ThemeFile';
 import { deepCopy } from '@shared/Util';
 import { formatString } from '@shared/utils/StringFormatter';
@@ -956,7 +956,7 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
   }
 
   onCurrentLogoSetChange = (value: string): void => {
-    updatePreferencesData({ currentLogoSet: value });
+    updatePreferencesDataAsync({ currentLogoSet: value });
   }
 
   onCurrentThemeItemSelect = (value: string, index: number): void => {
@@ -978,7 +978,7 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
     if (index < this.props.logoSets.length) { // (Select a Logo Set)
       logoSet = this.props.logoSets[index];
     } else { logoSet = undefined; } // (Deselect the current logo set)
-    updatePreferencesData({ currentLogoSet: logoSet ? logoSet.id : '' });
+    updatePreferencesDataAsync({ currentLogoSet: logoSet ? logoSet.id : undefined });
   }
 
   getThemeName(id: string) {

--- a/src/shared/preferences/util.ts
+++ b/src/shared/preferences/util.ts
@@ -1,5 +1,6 @@
 import { autoCode } from '@shared/lang';
 import { LogLevel } from '@shared/Log/interface';
+import { delayedThrottle, delayedThrottleAsync } from '@shared/utils/throttle';
 import { TagFilterGroup } from 'flashpoint-launcher';
 import { BackIn } from '../back/types';
 import { BrowsePageLayout } from '../BrowsePageLayout';
@@ -10,21 +11,39 @@ import { deepCopy, parseVarStr } from '../Util';
 import { Coerce } from '../utils/Coerce';
 import { IObjectParserProp, ObjectParser } from '../utils/ObjectParser';
 import { AppPathOverride, AppPreferencesData, AppPreferencesDataMainWindow } from './interfaces';
-import {delayedThrottle} from '@shared/utils/throttle';
 
 export function updatePreferencesData(data: DeepPartial<AppPreferencesData>, send = true) {
   const preferences = window.Shared.preferences;
   // @TODO Figure out the delta change of the object tree, and only send the changes
   preferences.data = overwritePreferenceData(deepCopy(preferences.data), data);
-  if (preferences.onUpdate) { preferences.onUpdate(); }
   if (send) {
     sendPrefs();
   }
+  if (preferences.onUpdate) { preferences.onUpdate(); }
+}
+
+export async function updatePreferencesDataAsync(data: DeepPartial<AppPreferencesData>, send = true) {
+  const preferences = window.Shared.preferences;
+  // @TODO Figure out the delta change of the object tree, and only send the changes
+  preferences.data = overwritePreferenceData(deepCopy(preferences.data), data);
+  if (send) {
+    await sendPrefsAsync();
+  }
+  if (preferences.onUpdate) { preferences.onUpdate(); }
 }
 
 const sendPrefs = delayedThrottle(() => {
   const preferences = window.Shared.preferences;
   window.Shared.back.send(
+    BackIn.UPDATE_PREFERENCES,
+    preferences.data,
+    false
+  );
+}, 200);
+
+const sendPrefsAsync = delayedThrottleAsync(async () => {
+  const preferences = window.Shared.preferences;
+  await window.Shared.back.request(
     BackIn.UPDATE_PREFERENCES,
     preferences.data,
     false

--- a/src/shared/utils/throttle.ts
+++ b/src/shared/utils/throttle.ts
@@ -56,7 +56,7 @@ export function delayedThrottle<T extends AnyFunction>(callback: T, time:number)
  * @param callback Called when the timer ends
  * @param time Time in milliseconds before calling
  */
- export function delayedThrottleAsync<T extends AnyFunction>(callback: T, time:number): CallableCopyAsync<T> {
+export function delayedThrottleAsync<T extends AnyFunction>(callback: T, time:number): CallableCopyAsync<T> {
   // Store timeout
   let timeout: ReturnType<typeof setTimeout> | undefined;
   // Function that receives and records the events

--- a/src/shared/utils/throttle.ts
+++ b/src/shared/utils/throttle.ts
@@ -4,6 +4,10 @@ import { AnyFunction, ArgumentTypesOf } from '../interfaces';
 interface CallableCopy<T extends AnyFunction> extends Function {
   (...args: ArgumentTypesOf<T>): void;
 }
+/** A callable object that has the same argument types as T (and Promise<void> as the return type). */
+interface CallableCopyAsync<T extends AnyFunction> extends Function {
+  (...args: ArgumentTypesOf<T>): Promise<void>;
+}
 
 /**
  * Executes a callback immediately and starts a timer, only executes if timer is finished
@@ -43,6 +47,30 @@ export function delayedThrottle<T extends AnyFunction>(callback: T, time:number)
       timeout = undefined;
       callback(...args);
     }, time);
+  };
+  return throttler;
+}
+
+/**
+ * Executes a callback after a `time` millisecond timer, only starting the timer if it doesn't exist
+ * @param callback Called when the timer ends
+ * @param time Time in milliseconds before calling
+ */
+ export function delayedThrottleAsync<T extends AnyFunction>(callback: T, time:number): CallableCopyAsync<T> {
+  // Store timeout
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  // Function that receives and records the events
+  const throttler: CallableCopyAsync<T> = async function(...args) {
+    return new Promise(resolve => {
+      // Check if currently throttling
+      if (timeout != undefined) { resolve(); }
+      // Release event after some time
+      timeout = setTimeout(async function() {
+        timeout = undefined;
+        await callback(...args);
+        resolve();
+      }, time);
+    });
   };
   return throttler;
 }


### PR DESCRIPTION
This resolves #280.

Previously: the preference-changed event for logoSet (and hence the requests for the new logos, so that they can be displayed below the dropdown) was emitted without waiting for the `UPDATE_PREFERENCES` signal was sent to the backend. This was caused by a combination of throttling and using `send` instead of `request`. It resulted in a mixture of the previous and correct logo sets - some logo requests were processed by the backend pre-change, some post-change. The "new" images, once requested, were cached by the frontend until the *next* logoSet change.

Now: for logoSet only, we await the completion of the backend request before emitting the preference-changed event.