### PR TITLE
feat: pass fp path to launched games through env

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -336,6 +336,7 @@ export namespace GameLauncher {
     // level entire system when using Windows.
     // When using WINE on mac, the proxy variable is needed as well.
     return {
+      'FP_PATH': fpPath,
       // Add proxy env vars if it's running on linux
       ...(((process.platform === 'linux' || process.platform === 'darwin') && proxy !== '') ? { http_proxy: `http://${proxy}/`, HTTP_PROXY: `http://${proxy}/` } : null),
       // Copy this processes environment variables


### PR DESCRIPTION
Remove the need for scripts to figure out the fp path themselves.
Previously, scripts had to locate themselves, resulting in a lot of
duplicate code between scripts. Look at the fpdocker scripts, for example.