### PR TITLE
Resolve absolute Flashpoint path for services/extensions

### DIFF
--- a/src/back/extensions/util.ts
+++ b/src/back/extensions/util.ts
@@ -13,7 +13,7 @@ export async function parseAppVar(extId: string, appPath: string, launchCommand:
       case 'arch': return process.arch;
       case 'launchCommand': return launchCommand;
       case 'cwd': return fixSlashes(process.cwd());
-      case 'fpPath': return state.config ? fixSlashes(state.config.flashpointPath) : '';
+      case 'fpPath': return state.config ? path.resolve(fixSlashes(state.config.flashpointPath)) : '';
       case 'proxy': return state.preferences.browserModeProxy || '';
       default: {
         if (name.startsWith('extConf:')) {

--- a/src/shared/Util.ts
+++ b/src/shared/Util.ts
@@ -351,7 +351,7 @@ export function parseVarStr(str: string, config?: AppConfigData) {
   return parseVariableString(str, (name) => {
     switch (name) {
       case 'cwd': return fixSlashes(process.cwd());
-      case 'fpPath': return config ? fixSlashes(config.flashpointPath) : '';
+      case 'fpPath': return config ? path.resolve(fixSlashes(config.flashpointPath)) : '';
       default: return '';
     }
   });


### PR DESCRIPTION
Closes #413

I have a branch where I experimented with introducing ExtendedAppConfigData, which extends AppConfigData to add the property `fullFlashpointPath`. The type replaces AppConfigData nearly everywhere except for the extensions API (to prevent breaking) and when serializing the config back to JSON so that the value isn't written to disk (i.e. transient).

I did this since the absolute path is needed in a number of points throughout the project where it's currently cobbled together in different ways (e.g. IMainWindowExternal), but it still felt like a pretty heavy handed solution for a problem that ultimately can be solved with these two lines. Such an approach might be better long term however.