### PR TITLE
Add Wine to PATH if it's bundled in FPSoftware

### DIFF
--- a/src/back/GameLauncher.ts
+++ b/src/back/GameLauncher.ts
@@ -376,6 +376,12 @@ export namespace GameLauncher {
         ...newEnvVars, 'WINEDEBUG': 'fixme-all',
         ...(proxy !== '' ? {'http_proxy': `http://${proxy}/`, 'HTTP_PROXY': `http://${proxy}/`} : null)
       };
+      // If WINE's bin directory exists in FPSoftware, add it to the PATH
+      if (fs.existsSync(`${fpPath}/FPSoftware/Wine/bin`)) {
+        newEnvVars = {
+          ...newEnvVars, 'PATH': `${fpPath}/FPSoftware/Wine/bin:` + process.env.PATH
+        }
+      }
     }
     return {
       // Copy this processes environment variables


### PR DESCRIPTION
On Mac & Linux systems, check if the `FPSoftware/Wine/bin` directory exists relative to fpPath, which shall contain all binaries needed for Wine to function. If it does, add it to the PATH, so Wine launches without the user having to modify it themselves. The PATH will not be modified if the directory doesn't exist, or if the launcher is running on Windows (obviously).