### PR TITLE
fix: Correct platforms property in exported database response

### DIFF
--- a/src/back/responses.ts
+++ b/src/back/responses.ts
@@ -1448,7 +1448,7 @@ export function registerRequestCallbacks(state: BackState, init: () => Promise<v
     const res = 'Exported Database:' +
     `\nTag Categories: ${jsonFile.tags.categories.length.toString().padStart(5, ' ')} ` +
     `\nTags: ${jsonFile.tags.tags.length.toString().padStart(11, ' ')} ` +
-    `\nPlatforms: ${jsonFile.platforms.platforms.length.toString().padStart(9, ' ')} ` +
+    `\nPlatforms: ${jsonFile.platforms.length.toString().padStart(9, ' ')} ` +
     `\nGames: ${jsonFile.games.games.length.toString().padStart(14, ' ')} `;
 
     jsonFile = JSON.stringify(jsonFile, null, 0);


### PR DESCRIPTION
The function `findAllPlatforms()` in FPA returns an array of objects, not a dictionary. So `platforms` is not a property of `jsonFile.platforms` which lead to database not being exported.