### PR TITLE
Extend fpfss access token into extensions

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -640,7 +640,8 @@
     "badAntiVirus": "You appear to be using '{0}'.\nThis particular Antivirus is known to cause issues, and we recommend adding an exception to the Flashpoint folder.\n\nIf you only see a white screen when running Flash games you may need to reinstall Flashpoint to restore deleted files.\n\nSee the Wiki or Help tab for detailed instructions.",
     "openWiki": "Open Wiki",
     "openDiscord": "Join Discord Server",
-    "doNotShowAgain": "Do not show again"
+    "doNotShowAgain": "Do not show again",
+    "extFpfssConsent": "Extension with ID {0} is requesting access to your FPFSS token. Allow?\nThis means the extension will be able access your FPFSS account and perform actions on your behalf."
   },
   "libraries": {
     "arcade": "Games",
@@ -663,8 +664,6 @@
   },
   "extensions": {
     "fpssConsentRevokeTitle": "Revoke access to FPFSS",
-    "fpssConsentRevokeDesc": "Withdraw this extension's access to FPFSS",
-    "fpssConsentGrantTitle": "Allow access to FPFSS",
-    "fpssConsentGrantDesc": "You've blocked this extension from accessing FPFSS. Click to allow extension access to FPFSS"
+    "fpssConsentRevokeDesc": "Withdraw this extension's access to FPFSS"
   }
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -545,7 +545,8 @@
     "showImage": "Show Image",
     "searching": "Searching...",
     "loading": "Loading...",
-    "ok": "OK"
+    "ok": "OK",
+    "allow": "Allow"
   },
   "menu": {
     "viewThumbnailInFolder": "View Thumbnail in Folder",
@@ -659,5 +660,11 @@
     "techDesc": "Adds support for all other tech - Shockwave, Unity, Java, HTML5, etc.",
     "screenshots": "Logos & Screenshots",
     "screenshotsDesc": "Adds logos for Grid view and screenshots for all games."
+  },
+  "extensions": {
+    "fpssConsentRevokeTitle": "Revoke access to FPFSS",
+    "fpssConsentRevokeDesc": "Withdraw this extension's access to FPFSS",
+    "fpssConsentGrantTitle": "Allow access to FPFSS",
+    "fpssConsentGrantDesc": "You've blocked this extension from accessing FPFSS. Click to allow extension access to FPFSS"
   }
 }

--- a/src/back/extensions/ApiImplementation.ts
+++ b/src/back/extensions/ApiImplementation.ts
@@ -621,12 +621,22 @@ export function createApiFactory(extId: string, extManifest: IExtensionManifest,
       if (!state.socketServer.lastClient) {
         throw new Error('No connected client to handle FPFSS action.');
       }
-
-      const user = await state.socketServer.request(state.socketServer.lastClient, BackOut.FPFSS_ACTION);
-      if (user && user.accessToken) {
-        return user.accessToken;
-      } else {
-        throw new Error('Failed to get access token or user cancelled.');
+      try {
+        const user = await state.socketServer.request(state.socketServer.lastClient, BackOut.FPFSS_ACTION, extId);
+        if (user && user.accessToken) {
+          return user.accessToken;
+        } else {
+          throw new Error('Failed to get access token or user cancelled.');
+        }
+      } catch (error) {
+        const client = state.socketServer.lastClient;
+        const openDialog = state.socketServer.showMessageBoxBack(state, client);
+        await openDialog({
+          largeMessage: true,
+          message: (error instanceof Error) ? error.message : String(error),
+          buttons: [state.languageContainer.misc.ok]
+        });
+        throw error;
       }
     },
   };

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -207,7 +207,6 @@ const state: BackState = {
   resolveDialogEvents: new EventEmitter(),
   downloadController: new InstancedAbortController(),
   shortcuts: {},
-  pendingFpfssActions: new Map<string, (user: FpfssUser | null) => void>(),
 };
 
 main();

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -207,6 +207,7 @@ const state: BackState = {
   resolveDialogEvents: new EventEmitter(),
   downloadController: new InstancedAbortController(),
   shortcuts: {},
+  pendingFpfssActions: new Map<string, (user: flashpoint.FpfssUser | null) => void>(),
 };
 
 main();

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -6,7 +6,7 @@ import {
   stringifyArray
 } from '@shared/Util';
 import * as os from 'os';
-import { BackIn, BackInit, BackInitArgs, BackOut, BackResParams, ComponentState, ComponentStatus, DownloadDetails } from '@shared/back/types';
+import { BackIn, BackInit, BackInitArgs, BackOut, BackResParams, ComponentState, ComponentStatus, DownloadDetails, FpfssUser } from '@shared/back/types';
 import { getContentFolderByKey, getCurationFolder } from '@shared/curate/util';
 import { ILogoSet, LogoSet } from '@shared/extensions/interfaces';
 import { IBackProcessInfo, RecursivePartial } from '@shared/interfaces';
@@ -207,7 +207,7 @@ const state: BackState = {
   resolveDialogEvents: new EventEmitter(),
   downloadController: new InstancedAbortController(),
   shortcuts: {},
-  pendingFpfssActions: new Map<string, (user: flashpoint.FpfssUser | null) => void>(),
+  pendingFpfssActions: new Map<string, (user: FpfssUser | null) => void>(),
 };
 
 main();

--- a/src/back/responses.ts
+++ b/src/back/responses.ts
@@ -2476,14 +2476,6 @@ export function registerRequestCallbacks(state: BackState, init: () => Promise<v
     await fpDatabase.optimizeDatabase();
     state.socketServer.broadcast(BackOut.CANCEL_DIALOG, dialogId);
   });
-
-  state.socketServer.register(BackIn.FPFSS_ACTION_RESPONSE, (event, actionId: string, user?: FpfssUser) => {
-    const resolve = state.pendingFpfssActions.get(actionId);
-    if (resolve) {
-      resolve(user);
-      state.pendingFpfssActions.delete(actionId);
-    }
-  });
 }
 
 /**

--- a/src/back/responses.ts
+++ b/src/back/responses.ts
@@ -124,7 +124,7 @@ import {
 import { uuid } from './util/uuid';
 import { FPFSS_INFO_FILENAME } from '@shared/curate/fpfss';
 import { createSearchFilter } from '@back/util/search';
-import { FpfssUser } from '@back/types';
+import { FpfssUser } from '@shared/back/types';
 
 const axios = axiosImport.default;
 

--- a/src/back/responses.ts
+++ b/src/back/responses.ts
@@ -124,6 +124,7 @@ import {
 import { uuid } from './util/uuid';
 import { FPFSS_INFO_FILENAME } from '@shared/curate/fpfss';
 import { createSearchFilter } from '@back/util/search';
+import { FpfssUser } from '@back/types';
 
 const axios = axiosImport.default;
 
@@ -2474,6 +2475,14 @@ export function registerRequestCallbacks(state: BackState, init: () => Promise<v
     // Actually do the work now
     await fpDatabase.optimizeDatabase();
     state.socketServer.broadcast(BackOut.CANCEL_DIALOG, dialogId);
+  });
+
+  state.socketServer.register(BackIn.FPFSS_ACTION_RESPONSE, (event, actionId: string, user?: FpfssUser) => {
+    const resolve = state.pendingFpfssActions.get(actionId);
+    if (resolve) {
+      resolve(user);
+      state.pendingFpfssActions.delete(actionId);
+    }
   });
 }
 

--- a/src/back/types.ts
+++ b/src/back/types.ts
@@ -1,4 +1,4 @@
-import { BackInit, ComponentStatus } from '@shared/back/types';
+import { BackInit, ComponentStatus, FpfssUser } from '@shared/back/types';
 import { AppConfigData, AppExtConfigData } from '@shared/config/interfaces';
 import { ExecMapping, GamePropSuggestions, IBackProcessInfo, INamedBackProcessInfo } from '@shared/interfaces';
 import { LangContainer, LangFile } from '@shared/lang';
@@ -86,6 +86,7 @@ export type BackState = {
   resolveDialogEvents: EventEmitter;
   downloadController: InstancedAbortController;
   shortcuts: Record<string, string[]>;
+  pendingFpfssActions: Map<string, (user: FpfssUser | null) => void>;
 }
 
 export type BackQueryChache = {

--- a/src/back/types.ts
+++ b/src/back/types.ts
@@ -86,7 +86,6 @@ export type BackState = {
   resolveDialogEvents: EventEmitter;
   downloadController: InstancedAbortController;
   shortcuts: Record<string, string[]>;
-  pendingFpfssActions: Map<string, (user: FpfssUser | null) => void>;
 }
 
 export type BackQueryChache = {

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -663,6 +663,12 @@ export class App extends React.Component<AppProps> {
         }
       });
     });
+
+    window.Shared.back.register(BackOut.FPFSS_ACTION, (event, actionId) => {
+      this.performFpfssAction(async (user) => {
+        window.Shared.back.send(BackIn.FPFSS_ACTION_RESPONSE, actionId, user);
+      });
+    });
   }
 
 

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -69,9 +69,6 @@ export type AppProps = AppOwnProps & RouteComponentProps & WithViewProps & WithF
 export class App extends React.Component<AppProps> {
   appRef: React.RefObject<HTMLDivElement>;
 
-  static contextType = LangContext;
-  declare context: React.ContextType<typeof LangContext>;
-
   constructor(props: AppProps) {
     super(props);
 
@@ -1224,7 +1221,7 @@ export class App extends React.Component<AppProps> {
                     buttons: ['Ok'],
                   };
                   if (error.code === 'ENOENT') {
-                    opts.title = this.context.dialog.fileNotFound;
+                    opts.title = this.props.main.lang.dialog.fileNotFound;
                     opts.message = (
                       'Failed to find the game file.\n' +
                         'If you are using Flashpoint Infinity, make sure you download the game first.\n'

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -674,8 +674,6 @@ export class App extends React.Component<AppProps> {
           this.performFpfssAction(async (user) => {
             resolve(user);
           });
-        } else if (previousConsent === false) {
-          reject(new Error('Extension is not allowed to access FPFSS token'));
         } else {
           const msg = formatString(this.props.main.lang.dialog.extFpfssConsent, extId) as string;
           remote.dialog.showMessageBox({

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -671,6 +671,8 @@ export class App extends React.Component<AppProps> {
           this.performFpfssAction(async (user) => {
             resolve(user);
           });
+        } else if (previousConsent === false) {
+          reject(new Error('Extension is not allowed to access FPFSS token'));
         } else {
           const msg = formatString(this.props.main.lang.dialog.extFpfssConsent, extId) as string;
           remote.dialog.showMessageBox({

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -664,13 +664,31 @@ export class App extends React.Component<AppProps> {
       });
     });
 
-    window.Shared.back.register(BackOut.FPFSS_ACTION, (event, actionId) => {
-      this.performFpfssAction(async (user) => {
-        window.Shared.back.send(BackIn.FPFSS_ACTION_RESPONSE, actionId, user);
+    window.Shared.back.register(BackOut.BROWSE_VIEW_PAGE, (event, data) => {
+      // Dispath addData for the given view
+      this.props.searchActions.addData({
+        view: data.viewId,
+        data: {
+          searchId: data.searchId,
+          page: data.page,
+          games: data.games,
+        }
+      });
+    });
+
+    window.Shared.back.register(BackOut.FPFSS_ACTION, async () => {
+      return new Promise((resolve, reject) => {
+        this.performFpfssAction(async (user) => {
+          try {
+            resolve(user);
+          }
+          catch (error) {
+            reject(error);
+          }
+        });
       });
     });
   }
-
 
   init() {
     window.Shared.back.onStateChange = (state) => {

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -671,8 +671,6 @@ export class App extends React.Component<AppProps> {
           this.performFpfssAction(async (user) => {
             resolve(user);
           });
-        } else if (previousConsent === false) {
-          reject(new Error('Extension is not allowed to access FPFSS token'));
         } else {
           const msg = formatString(this.props.main.lang.dialog.extFpfssConsent, extId) as string;
           remote.dialog.showMessageBox({

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -691,12 +691,10 @@ export class App extends React.Component<AppProps> {
                   saveFpfssConsentExt(extId, true);
                   resolve(user);
                 } else {
-                  saveFpfssConsentExt(extId, false);
                   reject(new Error('Launcher was unable to get FPFSS token'));
                 }
               });
             } else {
-              saveFpfssConsentExt(extId, false);
               reject(new Error('User denied access to FPFSS token'));
             }
           }).catch((error) => {

--- a/src/renderer/components/app.tsx
+++ b/src/renderer/components/app.tsx
@@ -16,6 +16,7 @@ import { getFileServerURL, mapFpfssGameToLocal, mapLocalToFpfssGame, recursiveRe
 import { arrayShallowStrictEquals } from '@shared/utils/compare';
 import { debounce } from '@shared/utils/debounce';
 import { newGame } from '@shared/utils/misc';
+import { formatString } from '@shared/utils/StringFormatter';
 import axios from 'axios';
 import { clipboard, ipcRenderer, Menu, MenuItemConstructorOptions } from 'electron';
 import {
@@ -676,13 +677,14 @@ export class App extends React.Component<AppProps> {
         } else if (previousConsent === false) {
           reject(new Error('Extension is not allowed to access FPFSS token'));
         } else {
+          const msg = formatString(this.props.main.lang.dialog.extFpfssConsent, extId) as string;
           remote.dialog.showMessageBox({
             type: 'question',
             title: 'FPFSS Extension Access',
-            message: `Extension with ID ${extId} is requesting access to your FPFSS token. Allow?`,
-            buttons: [this.context.misc.yes, this.context.misc.no],
+            message: msg,
+            buttons: [this.props.main.lang.misc.yes, this.props.main.lang.misc.no],
             defaultId: 1,
-            cancelId: 1,
+            cancelId: 1
           })
           .then(({ response }) => {
             if (response === 0) {

--- a/src/renderer/components/pages/ConfigPage.tsx
+++ b/src/renderer/components/pages/ConfigPage.tsx
@@ -787,13 +787,6 @@ export class ConfigPage extends React.Component<ConfigPageProps, ConfigPageState
               value={allStrings.curate.delete}
               onClick={() => this.onExtFPFSSConsentChange(ext.id, 'revoke')} />
           ) : undefined }
-          {(fpfssConsent === false) ? (
-            <ConfigBoxInnerButton
-              title={allStrings.extensions.fpssConsentGrantTitle}
-              description={allStrings.extensions.fpssConsentGrantDesc}
-              value={allStrings.misc.allow}
-              onClick={() => this.onExtFPFSSConsentChange(ext.id, 'grant')} />
-          ) : undefined }
           </div>
         </div>
       );

--- a/src/renderer/fpfss.ts
+++ b/src/renderer/fpfss.ts
@@ -11,7 +11,7 @@ export async function fpfssLogin(createDialog: typeof mainActions.createDialog, 
   const tokenUrl = `${fpfssBaseUrl}/auth/device`;
   const data = {
     'client_id': 'flashpoint-launcher',
-    'scope': 'identity game:read game:edit submission:read submission:read-files',
+    'scope': 'identity game:read game:edit submission:read submission:read-files index:read',
   };
   const formData = new URLSearchParams(data).toString();
   const res = await axios.post(tokenUrl, formData, {

--- a/src/renderer/fpfss.ts
+++ b/src/renderer/fpfss.ts
@@ -111,3 +111,56 @@ export async function fpfssLogin(createDialog: typeof mainActions.createDialog, 
     cancelDialog(dialog.id);
   });
 }
+
+/**
+ * 
+ * @param extId The extension ID
+ * @returns The consent status for the extension
+ */
+
+export function getFpfssConsentExt(extId: string): boolean | undefined {
+  const consentData = localStorage.getItem('fpfss:extension_consent');
+  if (!consentData) {
+      return undefined;
+  }
+
+  try {
+      const consentMap = consentData ? JSON.parse(consentData) : {};
+      return consentMap[extId];
+  } catch (error) {
+      console.error('Failed to parse consent data:', error);
+      return undefined;
+  }
+}
+
+/**
+* 
+* @param extId The extension ID
+* @param status The consent status
+*/
+export function saveFpfssConsentExt(extId: string, status: boolean): void {
+  try {
+    const consentData = localStorage.getItem('fpfss:extension_consent');
+    const consentMap = consentData ? JSON.parse(consentData) : {};
+    consentMap[extId] = status;
+    localStorage.setItem('fpfss:extension_consent', JSON.stringify(consentMap));
+  } catch (error) {
+    console.error('Failed to parse or save consent data:', error);
+  }
+}
+
+/**
+ * @param extId The extension ID
+ */
+export function clearFpfssConsentExt(extId: string): void {
+  const consentData = localStorage.getItem('fpfss:extension_consent');
+  if (!consentData) { return; }
+  
+  try {
+    const consentMap = JSON.parse(consentData);
+    delete consentMap[extId];
+    localStorage.setItem('fpfss:extension_consent', JSON.stringify(consentMap));
+  } catch (error) {
+    console.error('Failed to parse consent data:', error);
+  }
+}

--- a/src/shared/back/types.ts
+++ b/src/shared/back/types.ts
@@ -198,7 +198,6 @@ export enum BackIn {
   // Tests
   TEST_RECONNECTIONS,
 
-  FPFSS_ACTION_RESPONSE,
 }
 
 export enum BackOut {
@@ -441,7 +440,6 @@ export type BackInTemplate = SocketTemplate<BackIn, {
   // Tests
   [BackIn.TEST_RECONNECTIONS]: () => void;
 
-  [BackIn.FPFSS_ACTION_RESPONSE]: (actionId: string, data: FpfssUser) => void;
 }>
 
 export type BackOutTemplate = SocketTemplate<BackOut, {
@@ -525,7 +523,7 @@ export type BackOutTemplate = SocketTemplate<BackOut, {
   [BackOut.UPDATE_DIALOG_MESSAGE]: (message: string, dialogId: string) => void;
   [BackOut.UPDATE_DIALOG_FIELD_VALUE]: (dialogId: string, name: string, value: any) => void;
 
-  [BackOut.FPFSS_ACTION]: (actionId: string) => void;
+  [BackOut.FPFSS_ACTION]: () => FpfssUser | undefined;
 }>
 
 export type BackResTemplate = BackOutTemplate & BackInTemplate;

--- a/src/shared/back/types.ts
+++ b/src/shared/back/types.ts
@@ -523,7 +523,7 @@ export type BackOutTemplate = SocketTemplate<BackOut, {
   [BackOut.UPDATE_DIALOG_MESSAGE]: (message: string, dialogId: string) => void;
   [BackOut.UPDATE_DIALOG_FIELD_VALUE]: (dialogId: string, name: string, value: any) => void;
 
-  [BackOut.FPFSS_ACTION]: () => FpfssUser | undefined;
+  [BackOut.FPFSS_ACTION]: (extId: string) => FpfssUser | undefined;
 }>
 
 export type BackResTemplate = BackOutTemplate & BackInTemplate;

--- a/src/shared/back/types.ts
+++ b/src/shared/back/types.ts
@@ -197,6 +197,8 @@ export enum BackIn {
 
   // Tests
   TEST_RECONNECTIONS,
+
+  FPFSS_ACTION_RESPONSE,
 }
 
 export enum BackOut {
@@ -278,6 +280,8 @@ export enum BackOut {
   CANCEL_DIALOG,
   UPDATE_DIALOG_MESSAGE,
   UPDATE_DIALOG_FIELD_VALUE,
+
+  FPFSS_ACTION
 }
 
 export const BackRes = {
@@ -436,6 +440,8 @@ export type BackInTemplate = SocketTemplate<BackIn, {
 
   // Tests
   [BackIn.TEST_RECONNECTIONS]: () => void;
+
+  [BackIn.FPFSS_ACTION_RESPONSE]: (actionId: string, data: FpfssUser) => void;
 }>
 
 export type BackOutTemplate = SocketTemplate<BackOut, {
@@ -518,6 +524,8 @@ export type BackOutTemplate = SocketTemplate<BackOut, {
   [BackOut.CANCEL_DIALOG]: (dialogId: string) => void;
   [BackOut.UPDATE_DIALOG_MESSAGE]: (message: string, dialogId: string) => void;
   [BackOut.UPDATE_DIALOG_FIELD_VALUE]: (dialogId: string, name: string, value: any) => void;
+
+  [BackOut.FPFSS_ACTION]: (actionId: string) => void;
 }>
 
 export type BackResTemplate = BackOutTemplate & BackInTemplate;

--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -559,6 +559,7 @@ const langTemplate = {
     'searching',
     'loading',
     'ok',
+    'allow'
   ] as const,
   menu: [
     'viewThumbnailInFolder',
@@ -657,6 +658,12 @@ const langTemplate = {
     'openDiscord',
     'doNotShowAgain',
   ] as const,
+  extensions: [
+    'fpssConsentRevokeTitle',
+    'fpssConsentRevokeDesc',
+    'fpssConsentGrantTitle',
+    'fpssConsentGrantDesc',
+  ]
   // libraries: [], // (This is dynamically populated in run-time)
 } as const;
 

--- a/src/shared/lang.ts
+++ b/src/shared/lang.ts
@@ -657,6 +657,7 @@ const langTemplate = {
     'openWiki',
     'openDiscord',
     'doNotShowAgain',
+    'extFpfssConsent',
   ] as const,
   extensions: [
     'fpssConsentRevokeTitle',

--- a/typings/flashpoint-launcher.d.ts
+++ b/typings/flashpoint-launcher.d.ts
@@ -1645,4 +1645,8 @@ declare module 'flashpoint-launcher' {
          */
       upgradeConfig(version: string, config: any): any;
     }
+
+    namespace fpfss {
+        function getAccessToken(): Promise<string>;
+    }
 }


### PR DESCRIPTION
This PR introduces the `getAccessToken()` method in a new flashpoint.fpfss namespace, allowing extensions to get access token for the logged in user with FPFSS.

The way it works is that the frontend will still handle the calls to FPFSS and the backend acts like a proxy between the extension and the frontend ~~using a new state `pendingFpfssActions` to keep track of calls between frontend and backend.~~

So even if the user is logged out and the extensions call `getAccessToken()` the main render process will trigger a login to FPFSS by opening the web browser.

**NOTE** there is no warning here, the web browser will open immediately asking for user permission

EDIT 1:
Consent mechanism implemented as discussed. Only the first time the extensions request access to FPFSS the user will be prompted to allow access. The access can be revoked in the config page.

~~I think we really should split this `performFpfssAction` into two methods, one for internal application stuff and another one for extensions. By allowing for extensions access `performFpfssAction` through `getAccessToken` without any form of checks we are essentially opening up for credential stealing of the bearer token.~~

~~For this reasion I don't want _any_ extensions by default to be allowed to your access token without consent the first time the extensions tries to call this method. Thoughts on this?~~