### PR TITLE
Reload extension when hotkey for window reload is pressed

### DIFF
--- a/src/back/extensions/ExtensionService.ts
+++ b/src/back/extensions/ExtensionService.ts
@@ -94,6 +94,15 @@ export class ExtensionService {
   }
 
   /**
+   * Load all extensions
+   */
+  public async loadAll(): Promise<void | void[]> {
+    return this.installedExtensionsReady.wait().then(() => {
+      return Promise.all(this._extensions.map(ext => this._loadExtension(ext)));
+    });
+  }
+
+  /**
    * Loads an extension (returns immediately if already loaded)
    *
    * @param extId ID of extension to load

--- a/src/back/responses.ts
+++ b/src/back/responses.ts
@@ -137,8 +137,10 @@ const axios = axiosImport.default;
 export function registerRequestCallbacks(state: BackState, init: () => Promise<void>): void {
   state.socketServer.register(BackIn.KEEP_ALIVE, () => {});
 
-  state.socketServer.register(BackIn.PREP_RELOAD_WINDOW, () => {
+  state.socketServer.register(BackIn.PREP_RELOAD_WINDOW, async () => {
     state.ignoreQuit = true;
+    await state.extensionsService.unloadAll();
+    await state.extensionsService.loadAll();
     setTimeout(() => {
       state.ignoreQuit = false;
     }, 1000);


### PR DESCRIPTION
The backend now reloads all extensions when receiving message from frontend that a reload has happened by hotkey (ctrl+shift+r).

This closes #441 