### PR TITLE
Consistent User-Agent for all requests

### DIFF
--- a/src/back/Axios.ts
+++ b/src/back/Axios.ts
@@ -1,0 +1,11 @@
+import { UserAgent } from '@shared/Util';
+import * as axiosImport from 'axios';
+const axios = axiosImport.default;
+
+const axiosInstance = axios.create({
+    headers: {
+        'User-Agent': UserAgent
+    }
+});
+
+export default axiosInstance;

--- a/src/back/curate/util.ts
+++ b/src/back/curate/util.ts
@@ -9,7 +9,7 @@ import { CURATIONS_FOLDER_WORKING } from '@shared/constants';
 import { getContentFolderByKey } from '@shared/curate/util';
 import { GamePropSuggestions } from '@shared/interfaces';
 import { LangContainer } from '@shared/lang';
-import axios from 'axios';
+import axiosInstance from '@back/Axios';
 import { AddAppCuration, CurationFpfssInfo, CurationState, CurationWarnings, LoadedCuration } from 'flashpoint-launcher';
 import * as fs from 'fs-extra';
 import * as http from 'http';
@@ -298,7 +298,7 @@ export async function makeCurationFromGame(state: BackState, gameId: string, ski
       const destPath = path.join(curPath, 'logo.png');
       const url = new URL(logoRelPath, state.preferences.onDemandBaseUrl);
       const writer = fs.createWriteStream(destPath);
-      await axios.get(url.href, {
+      await axiosInstance.get(url.href, {
         responseType: 'stream',
       }).then((response) => {
         return new Promise<void>((resolve, reject) => {
@@ -321,7 +321,7 @@ export async function makeCurationFromGame(state: BackState, gameId: string, ski
       const destPath = path.join(curPath, 'ss.png');
       const url = new URL(screenshotRelPath, state.preferences.onDemandBaseUrl);
       const writer = fs.createWriteStream(destPath);
-      await axios.get(url.href, {
+      await axiosInstance.get(url.href, {
         responseType: 'stream',
       }).then((response) => {
         return new Promise<void>((resolve, reject) => {

--- a/src/back/index.ts
+++ b/src/back/index.ts
@@ -32,7 +32,7 @@ import {
   CURATIONS_FOLDER_TEMP,
   CURATIONS_FOLDER_WORKING, CURATION_META_FILENAMES
 } from '@shared/constants';
-import axios from 'axios';
+import axiosInstance from './Axios';
 import { FlashpointArchive, enableDebug, loggerSusbcribe } from '@fparchive/flashpoint-archive';
 import { Tail } from 'tail';
 import { ConfigFile } from './ConfigFile';
@@ -1423,7 +1423,7 @@ async function updateFileServerDownloadQueue() {
       url += '?type=jpg';
     }
     // Use arraybuffer since it's small memory footprint anyway
-    await axios.get(url, { responseType: 'arraybuffer' })
+    await axiosInstance.get(url, { responseType: 'arraybuffer' })
     .then(async (res) => {
       // Save response to image file
       const imageData = res.data;

--- a/src/back/sync.ts
+++ b/src/back/sync.ts
@@ -1,5 +1,5 @@
 import { GameRedirect, RemoteCategory, RemoteDeletedGamesRes, RemoteGamesRes, RemotePlatform, RemoteTag } from '@fparchive/flashpoint-archive';
-import axios from 'axios';
+import axiosInstance from './Axios';
 import { GameMetadataSource } from 'flashpoint-launcher';
 import { camelCase, transform } from 'lodash';
 import { fpDatabase } from '.';
@@ -8,7 +8,7 @@ export async function syncTags(source: GameMetadataSource): Promise<Date> {
   const tagsUrl = `${source.baseUrl}/api/tags?after=${source.tags.latestUpdateTime}`;
   const nextLatestDate = source.tags.latestUpdateTime;
 
-  const res = await axios.get(tagsUrl)
+  const res = await axiosInstance.get(tagsUrl)
   .catch((err) => {
     throw 'Failed to search tags';
   });
@@ -44,7 +44,7 @@ export async function syncTags(source: GameMetadataSource): Promise<Date> {
 export async function syncPlatforms(source: GameMetadataSource): Promise<Date> {
   const platformsUrl = `${source.baseUrl}/api/platforms?after=${source.tags.latestUpdateTime}`;
 
-  const res = await axios.get(platformsUrl)
+  const res = await axiosInstance.get(platformsUrl)
   .catch((err) => {
     throw 'Failed to search platforms';
   });
@@ -87,7 +87,7 @@ export async function syncGames(source: GameMetadataSource, dataPacksFolder: str
   while (true) {
     const reqUrl = `${gamesUrl}?after=${source.games.latestUpdateTime}&before=${capUpdateTime.toISOString()}&broad=true&afterId=${nextId}`;
     console.log(reqUrl);
-    const res = await axios.get(reqUrl)
+    const res = await axiosInstance.get(reqUrl)
     .catch((err) => {
       throw 'Failed to search games';
     });
@@ -120,7 +120,7 @@ export async function syncGames(source: GameMetadataSource, dataPacksFolder: str
 
   // -- Deleted Games -- //
   const reqUrl = `${deletedUrl}`;
-  const res = await axios.get(reqUrl)
+  const res = await axiosInstance.get(reqUrl)
   .catch((err) => {
     throw 'Failed to search deleted games';
   });
@@ -134,7 +134,7 @@ export async function syncGames(source: GameMetadataSource, dataPacksFolder: str
 
 export async function syncRedirects(source: GameMetadataSource): Promise<void> {
   const gamesUrl = `${source.baseUrl}/api/game-redirects`;
-  const res = await axios.get(gamesUrl)
+  const res = await axiosInstance.get(gamesUrl)
   .catch((err) => {
     throw 'Failed to search game redirects';
   });
@@ -155,7 +155,7 @@ export async function getMetaUpdateInfo(source: GameMetadataSource, accurate?: b
   }
   const countUrl = `${source.baseUrl}/api/games/updates?after=${fromScratch ? '1970-01-01' : d.toISOString()}`;
   try {
-    const res = await axios.get(countUrl);
+    const res = await axiosInstance.get(countUrl);
     return res.data.total;
   } catch (err) {
     log.error('Launcher', 'Error fetching update info for ' + countUrl + ' - ' + err);

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -1,6 +1,6 @@
 import * as remoteMain from '@electron/remote/main';
 import { InitRendererChannel, InitRendererData } from '@shared/IPC';
-import { createErrorProxy } from '@shared/Util';
+import { createErrorProxy, UserAgent } from '@shared/Util';
 import { SocketClient } from '@shared/back/SocketClient';
 import { BackIn, BackInitArgs, BackOut } from '@shared/back/types';
 import { AppConfigData } from '@shared/config/interfaces';
@@ -311,6 +311,11 @@ export function main(init: Init): void {
       state.socket.send(BackIn.SET_LOCALE, app.getLocale().toLowerCase());
       state._sentLocaleCode = true;
     }
+    // Set user agent for all requests
+    session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+      details.requestHeaders['User-Agent'] = UserAgent;
+      callback({ cancel: false, requestHeaders: details.requestHeaders });
+    });
     // Reject all permission requests since we don't need any permissions.
     session.defaultSession.setPermissionRequestHandler(
       (webContents, permission, callback) => callback(false)

--- a/src/shared/Util.ts
+++ b/src/shared/Util.ts
@@ -6,6 +6,7 @@ import { DownloadDetails } from './back/types';
 import { AppConfigData } from './config/interfaces';
 import { parseVariableString } from './utils/VariableString';
 import { throttle } from './utils/throttle';
+import { VERSION } from './version';
 
 const axios = axiosImport.default;
 
@@ -418,6 +419,9 @@ export function tagSort(tagA: Tag, tagB: Tag): number {
 
 export async function downloadFile(url: string, filePath: string, abortSignal?: AbortSignal, onProgress?: (percent: number) => void, onDetails?: (details: DownloadDetails) => void, options?: axiosImport.AxiosRequestConfig): Promise<number> {
   try {
+    options = options || {};
+    options.headers = options.headers || {};
+    options.headers['User-Agent'] = UserAgent;
     const res = await axios.get(url, {
       ...options,
       responseType: 'stream',
@@ -658,3 +662,5 @@ export function mapLocalToFpfssGame(game: Game): FpfssGame {
   };
   return fg;
 }
+
+export const UserAgent = `Flashpoint Launcher/${VERSION}`;


### PR DESCRIPTION
This PR adds a shared User-Agent for all requests in the launcher. The UA is `Flashpoint Launcher/${VERSION}` which will show up in FPFSS logs as of writing this: `userAgent="Flashpoint Launcher/2024-12-19 (b500e31c)"`

The purpose of this UA is to ensure we have a valid UA set and that we are able to track which versions of launcher is hitting out APIs.

Exmple fpfss log:

```
time="2024-12-19T02:32:12.638044589+01:00" level=debug msg="request captured" func=github.com/FlashpointProject/flashpoint-submission-system/transport.InitApp.LogRequestHandler.func4 file="/home/mike/code/flashpoint-submission-system/logging/logging.go:87" commit=deadbeef duration_ns=1660690 ip=172.27.80.1 method=GET requestID=a021ubwvwp2blb1l runID=hf926sos size=12 statusCode=200 uri="/api/games/updates?after=2024-12-08T02:33:49.321Z" userAgent="Flashpoint Launcher/2024-12-19 (b500e31c)
```