### PR TITLE
fix: Make Ruffle Executable If Not on Windows

### DIFF
--- a/extensions/core-ruffle/src/middleware/standalone.ts
+++ b/extensions/core-ruffle/src/middleware/standalone.ts
@@ -217,6 +217,8 @@ export class RuffleStandaloneMiddleware implements IGameMiddleware {
         throw `Error downloading Ruffle version "${middlewareConfig.version}": ${e}`;
       }
     }
+    // Make standalone ruffle executable if not Windows
+    if (executable === 'ruffle') { await fs.promises.chmod(execPath, 0o775); }
 
     // Add any configured ruffle params to the launch args
     const launchArgs = coerceToStringArray(gameLaunchInfo.launchInfo.gameArgs);


### PR DESCRIPTION
Automatically give the standalone Ruffle binary permission to execute on non-Windows OSes. This allows Mac & Linux users to run Ruffle without having to manually give it execute perms beforehand.