### PR TITLE
fix: Ruffle doesn't launch when using await with chmod

### DIFF
--- a/extensions/core-ruffle/src/middleware/standalone.ts
+++ b/extensions/core-ruffle/src/middleware/standalone.ts
@@ -221,7 +221,7 @@ export class RuffleStandaloneMiddleware implements IGameMiddleware {
       }
     }
     // Make standalone ruffle executable if not Windows
-    if (executable === 'ruffle') { await fs.promises.chmod(execPath, 0o775); }
+    if (executable === 'ruffle') { fs.promises.chmod(execPath, 0o775); }
 
     // Add any configured ruffle params to the launch args
     const launchArgs = coerceToStringArray(gameLaunchInfo.launchInfo.gameArgs);


### PR DESCRIPTION
Using await with the chmod function when setting file permissions for Ruffle breaks the rest of the code, for some reason. Remove await so the code works properly.