### PR TITLE
fix: Launching Ruffle on macOS

### DIFF
--- a/extensions/core-ruffle/src/middleware/standalone.ts
+++ b/extensions/core-ruffle/src/middleware/standalone.ts
@@ -189,7 +189,8 @@ export class RuffleStandaloneMiddleware implements IGameMiddleware {
     };
 
     // Replace application path with ruffle standalone executable (<base>/<version>/<executable>)
-    const executable = os.platform() === 'win32' ? 'ruffle.exe' : 'ruffle';
+    const osPlatform = os.platform();
+    const executable = osPlatform === 'win32' ? 'ruffle.exe' : (osPlatform === 'darwin' ? 'Ruffle.app/Contents/MacOS/ruffle' : 'ruffle');
     const execPath = path.join(this.ruffleStandaloneRoot, middlewareConfig.version, executable);
 
     // If exec path is missing, we need to download the correct version
@@ -221,7 +222,7 @@ export class RuffleStandaloneMiddleware implements IGameMiddleware {
       }
     }
     // Make standalone ruffle executable if not Windows
-    if (executable === 'ruffle') { fs.promises.chmod(execPath, 0o775); }
+    if (osPlatform !== 'win32') { fs.promises.chmod(execPath, 0o775); }
 
     // Add any configured ruffle params to the launch args
     const launchArgs = coerceToStringArray(gameLaunchInfo.launchInfo.gameArgs);


### PR DESCRIPTION
When Ruffle is downloaded by the launcher on macOS, it is downloaded as an application rather than a standalone binary. This results in the launcher being unable to launch Ruffle, as it expects to find it in `ruffle` instead of its actual location (`Ruffle.app/Contents/MacOS/ruffle`), relative to `Data/Ruffle/standalone/latest`. This PR corrects that behavior, allowing the launcher to automatically set the proper permissions and launch Ruffle on macOS like it can on Linux.