### PR TITLE
Fix for search filter spaces

### DIFF
--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -679,7 +679,7 @@ function SearchableSelectDropdown<T extends SearchableSelectItem>(props: Searcha
   // Split the items into 2 halves - Selected and not selected, then merge
 
   const filteredItems = React.useMemo(() => {
-    const lowerSearch = search.toLowerCase().replace(' ', '');
+    const lowerSearch = search.toLowerCase().replace(/\s+/g, '');
     const selectedItems = storedItems.filter((item) => item.value in selected);
     selectedItems.sort((a, b) => {
       if (selected[a.value] === 'whitelist' && selected[b.value] === 'blacklist') {
@@ -693,7 +693,7 @@ function SearchableSelectDropdown<T extends SearchableSelectItem>(props: Searcha
 
     return [
       ...selectedItems,
-      ...storedItems.filter((item) => !(item.value in selected) && item.orderVal.toLowerCase().includes(lowerSearch)),
+      ...storedItems.filter((item) => !(item.value in selected) && item.orderVal.toLowerCase().replace(/\s+/g, '').includes(lowerSearch)),
     ];
   }, [search, storedItems]);
 


### PR DESCRIPTION
If user search for something with single whitespace, no items would appear in the dropdown. This is a fix for it.

Before
<img width="237" height="182" alt="bilde" src="https://github.com/user-attachments/assets/f574cee4-8fe8-47ab-8eaa-fcd6649b5efb" />

after
<img width="466" height="469" alt="bilde" src="https://github.com/user-attachments/assets/2f40a587-b91e-49e9-a65e-1551a625121b" />
