### PR TITLE
feat: Portable mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ npm-debug.log.*
 /extensions/test
 /src/shared/version.ts
 Data
+ApplicationData
 
 # Jest related files
 /.coveralls.yml

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -18,6 +18,7 @@ import * as WebSocket from 'ws';
 import * as Util from './Util';
 import { Init } from './types';
 
+const APPLICATION_DATA = path.join(Util.getMainFolderPath(), 'ApplicationData');
 const TIMEOUT_DELAY = 60_000;
 
 const ALLOWED_HOSTS = [
@@ -94,6 +95,16 @@ export function main(init: Init): void {
   // -- Functions --
 
   async function startup(opts: LaunchOptions) {
+    // Portable mode - Switch behavior only if the directory doesn't exist at the default location,
+    // which is only on fresh installs or if the user manually added an ApplicationData folder
+    if (!fs.existsSync(path.join(app.getPath('appData'), app.getName())) || fs.existsSync(APPLICATION_DATA)) {
+      if (process.platform === 'win32' || process.platform === 'linux') {
+        app.setPath('userData', APPLICATION_DATA);
+        app.setPath('crashDumps', path.join(APPLICATION_DATA, 'Crash Dumps'));
+        app.setAppLogsPath(path.join(APPLICATION_DATA, 'Logs'));
+      }
+    }
+
     app.disableHardwareAcceleration();
 
     // Single process


### PR DESCRIPTION
Partially implements #505. I was able to move the `%appdata%/Electron/*` / `%appdata%/flashpoint-launcher/*` directories, but not `Temp`.

Launcher will only switch to portable mode if the user created an `ApplicationData` folder in the main directory OR if there is no existing folder in `%appdata%` (fresh installs). Existing installs are not impacted and will continue to work as normal.